### PR TITLE
metrics: switch to dashmap

### DIFF
--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/twitter/rustcommon/metrics"
 repository = "https://github.com/twitter/rustcommon"
 
 [dependencies]
-chashmap = "2.2.2"
+dashmap = "3.11.4"
 rustcommon-datastructures = { path = "../datastructures" }
 serde = "1.0.110"
 serde_derive = "1.0.110"

--- a/metrics/src/metrics/mod.rs
+++ b/metrics/src/metrics/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::Statistic;
 use crate::*;
-use chashmap::CHashMap;
+use dashmap::DashMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ where
     <T as Atomic>::Primitive: Default + PartialEq + Copy + From<u8>,
     u64: From<<T as Atomic>::Primitive>,
 {
-    data: CHashMap<String, Arc<Channel<T>>>,
+    data: DashMap<String, Arc<Channel<T>>>,
 }
 
 impl<T> Clone for Metrics<T>
@@ -40,7 +40,7 @@ where
 {
     pub fn new() -> Self {
         Self {
-            data: CHashMap::new(),
+            data: DashMap::new(),
         }
     }
 


### PR DESCRIPTION
dashmap offers better performance in benchmarks than the chashmap
does, particularly for heavily contended accesses.

Changes the internal storage of the metrics crate to use dashmap
instead, providing about a 2x speedup under heavy contention.
