### PR TITLE
ratelimiter: add function to return current rate

### DIFF
--- a/ratelimiter/examples/bursty.rs
+++ b/ratelimiter/examples/bursty.rs
@@ -8,7 +8,7 @@ fn main() {
     for strategy in &[Refill::Normal, Refill::Uniform] {
         println!("strategy: {:?}", strategy);
         let limiter = Ratelimiter::new(1, 1, 1);
-        limiter.strategy(*strategy);
+        limiter.set_strategy(*strategy);
         for i in 0..10 {
             limiter.wait();
             println!("{}: T -{}", time::precise_time_ns(), 10 - i);

--- a/ratelimiter/src/lib.rs
+++ b/ratelimiter/src/lib.rs
@@ -90,15 +90,20 @@ impl Ratelimiter {
 
     /// Changes the rate of the `Ratelimiter`. The new rate will be in effect on
     /// the next tick.
-    pub fn rate(&self, rate: u64) {
+    pub fn set_rate(&self, rate: u64) {
         self.tick.store(
             SECOND / (rate / self.quantum.load(Ordering::Relaxed)),
             Ordering::Relaxed,
         );
     }
 
+    /// Returns the current rate
+    pub fn rate(&self) -> u64 {
+        SECOND * self.quantum.load(Ordering::Relaxed) / self.tick.load(Ordering::Relaxed)
+    }
+
     /// Changes the refill strategy
-    pub fn strategy(&self, strategy: Refill) {
+    pub fn set_strategy(&self, strategy: Refill) {
         self.strategy.store(strategy as usize, Ordering::Relaxed)
     }
 


### PR DESCRIPTION
Adds a function to return the current rate and renames the
functions to set both rate and strategy.