### PR TITLE
metrics: add collection and scope to statistic trait

### DIFF
--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-metrics"
-version = "1.0.0"
+version = "1.0.1-alpha.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/metrics/src/common/statistic.rs
+++ b/metrics/src/common/statistic.rs
@@ -4,9 +4,26 @@
 
 use crate::common::source::Source;
 
+/// Statistics define what a given channel is tracking. The statistic must have
+/// a name and a source. There are additional methods which may return a value
+/// and have default implementations returning `None`. These additional fields
+/// may be used to specify the scope for a given statistic or other metadata.
 pub trait Statistic {
-    /// the reported name of the series
+    /// The name, which is used in the standard exposition format, eg:
+    /// `collection/scope/name/reading: value`
     fn name(&self) -> &str;
+
+    /// An optional collection, which is used in the standard exposition format,
+    /// eg: `collection/scope/name/reading: value`
+    fn collection(&self) -> Option<&str> {
+        None
+    }
+
+    /// An optional scope, which is used in the standard exposition format, eg:
+    /// `collection/scope/name/reading: value`
+    fn scope(&self) -> Option<&str> {
+        None
+    }
 
     /// the unit of measurement
     fn unit(&self) -> Option<&str> {
@@ -18,6 +35,6 @@ pub trait Statistic {
         None
     }
 
-    /// the source of the measurement
+    /// the source of the measurement, such as a counter or gauge
     fn source(&self) -> Source;
 }


### PR DESCRIPTION
Problem

We would like to be able to represent scoped metrics which are for a
given specific resource, a physical disk, a TCP session, a NUMA node,
etc. Currently, each statistic would put this directly in its `name`. This
prevents us from having a richer OpenMetrics / Prometheus exposition
format.

Solution

Adds additional methods named `collection` and `scope` to the trait
with defaulted implementations returning `None`. If either of these is
overridden for the concrete type, it may be used in exposition format.

Result

Users may create richer statistic types.
