### PR TITLE
add dedicated histogram crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "atomics",
     "datastructures",
+    "histogram",
     "logger",
     "metrics",
     "ratelimiter",

--- a/datastructures/src/histogram/mod.rs
+++ b/datastructures/src/histogram/mod.rs
@@ -800,15 +800,16 @@ mod tests {
 
     #[test]
     fn bounds_moving() {
-        let h = Histogram::<AtomicU64>::new(100, 3, Some(<Duration>::from_millis(1)), None);
+        let h = Histogram::<AtomicU64>::new(100, 3, Some(<Duration>::from_millis(20)), None);
         assert_eq!(h.total_count(), 0);
         for _ in 1..100 {
             let _ = h.increment(1_000_000, 1);
             assert_eq!(h.total_count(), 1);
             assert_eq!(h.percentile(0.0), Ok(100));
             assert_eq!(h.percentile(1.0), Ok(100));
-            std::thread::sleep(Duration::from_millis(2));
+            std::thread::sleep(Duration::from_millis(20));
         }
+        std::thread::sleep(Duration::from_millis(20));
         assert_eq!(h.percentile(0.0), Err(HistogramError::Empty));
         assert_eq!(h.percentile(1.0), Err(HistogramError::Empty));
         assert_eq!(h.total_count(), 0);

--- a/histogram/.gitignore
+++ b/histogram/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/histogram/CHANGELOG.md
+++ b/histogram/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+# 1.0.0 - 2020-09-01
+
+Initial release.

--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-histogram"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rustcommon-histogram"
+version = "0.1.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+edition = "2018"
+license = "Apache-2.0"
+description = "Histograms with summary metrics and precision guarantees"
+homepage = "https://github.com/twitter/rustcommon/datastructures"
+repository = "https://github.com/twitter/rustcommon"
+
+[dependencies]
+rustcommon-atomics = { path = "../atomics" }
+thiserror = "1.0.20"

--- a/histogram/README.md
+++ b/histogram/README.md
@@ -1,0 +1,58 @@
+# rustcommon-histogram
+
+Histogram implementations inspired by HDRHistogram which can be used for both
+single-threaded and multi-threaded applications.
+
+## Overview
+
+This crate provides a histogram implementation that is inspired by HDRHistogram.
+It preserves precision across a range of values and can be useful for producing
+percentile metrics for latency measurements or other readings. There are
+implementations of both atomic and non-atomic histograms with similar function
+signatures. The non-atomic forms should be preferred for single-threaded
+use-cases.
+
+## Getting Started
+
+### Building
+
+rustcommon is built with the standard Rust toolchain which can be installed and
+managed via [rustup](https://rustup.rs) or by following the directions on the
+Rust [website](https://www.rust-lang.org/).
+
+#### View library documentation
+```bash
+cargo doc --open
+```
+
+## Support
+
+Create a [new issue](https://github.com/twitter/rustcommon/issues/new) on GitHub.
+
+## Contributing
+
+We feel that a welcoming community is important and we ask that you follow
+Twitter's [Open Source Code of Conduct] in all interactions with the community.
+
+## Authors
+
+* Brian Martin <bmartin@twitter.com>
+
+A full list of [contributors] can be found on GitHub.
+
+Follow [@TwitterOSS](https://twitter.com/twitteross) on Twitter for updates.
+
+## License
+
+Copyright 2020 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0:
+https://www.apache.org/licenses/LICENSE-2.0
+
+## Security Issues?
+
+Please report sensitive security issues via Twitter's bug-bounty program
+(https://hackerone.com/twitter) rather than GitHub.
+
+[contributors]: https://github.com/twitter/rustcommon/graphs/contributors?type=a
+[Open Source Code of Conduct]: https://github.com/twitter/code-of-conduct/blob/master/code-of-conduct.md

--- a/histogram/src/bucket/mod.rs
+++ b/histogram/src/bucket/mod.rs
@@ -1,0 +1,39 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::Counter;
+
+/// A `Bucket` stores a count across a range of values
+pub struct Bucket<Value, Count> {
+    pub(crate) min: Value,
+    pub(crate) max: Value,
+    pub(crate) value: Value,
+    pub(crate) count: Count,
+}
+
+impl<Value, Count> Bucket<Value, Count>
+where
+    Value: Copy + std::ops::Sub<Output = Value>,
+    Count: Counter,
+{
+    /// Return the minimum value storable in the `Bucket`
+    pub fn min(&self) -> Value {
+        self.min
+    }
+
+    /// Return the nominal value for the `Bucket`
+    pub fn value(&self) -> Value {
+        self.value
+    }
+
+    /// Return the count of values recorded into this `Bucket`
+    pub fn count(&self) -> Count {
+        self.count
+    }
+
+    /// Returns the range of values storable in this `Bucket`
+    pub fn width(&self) -> Value {
+        self.max - self.min
+    }
+}

--- a/histogram/src/counter/mod.rs
+++ b/histogram/src/counter/mod.rs
@@ -1,0 +1,67 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+pub trait AtomicCounter:
+    rustcommon_atomics::Atomic
+    + rustcommon_atomics::Unsigned
+    + rustcommon_atomics::SaturatingArithmetic
+    + Default
+{
+}
+
+impl AtomicCounter for rustcommon_atomics::AtomicU8 {}
+impl AtomicCounter for rustcommon_atomics::AtomicU16 {}
+impl AtomicCounter for rustcommon_atomics::AtomicU32 {}
+impl AtomicCounter for rustcommon_atomics::AtomicU64 {}
+impl AtomicCounter for rustcommon_atomics::AtomicUsize {}
+
+pub trait Counter: Default + Copy {
+    fn saturating_add(&mut self, value: Self);
+    fn saturating_sub(&mut self, value: Self);
+}
+impl Counter for u8 {
+    fn saturating_add(&mut self, value: Self) {
+        *self = (*self as u8).saturating_add(value);
+    }
+
+    fn saturating_sub(&mut self, value: Self) {
+        *self = (*self as u8).saturating_sub(value);
+    }
+}
+impl Counter for u16 {
+    fn saturating_add(&mut self, value: Self) {
+        *self = (*self as u16).saturating_add(value);
+    }
+
+    fn saturating_sub(&mut self, value: Self) {
+        *self = (*self as u16).saturating_sub(value);
+    }
+}
+impl Counter for u32 {
+    fn saturating_add(&mut self, value: Self) {
+        *self = (*self as u32).saturating_add(value);
+    }
+
+    fn saturating_sub(&mut self, value: Self) {
+        *self = (*self as u32).saturating_sub(value);
+    }
+}
+impl Counter for u64 {
+    fn saturating_add(&mut self, value: Self) {
+        *self = (*self as u64).saturating_add(value);
+    }
+
+    fn saturating_sub(&mut self, value: Self) {
+        *self = (*self as u64).saturating_sub(value);
+    }
+}
+impl Counter for usize {
+    fn saturating_add(&mut self, value: Self) {
+        *self = (*self as usize).saturating_add(value);
+    }
+
+    fn saturating_sub(&mut self, value: Self) {
+        *self = (*self as usize).saturating_sub(value);
+    }
+}

--- a/histogram/src/error/mod.rs
+++ b/histogram/src/error/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum HistogramError {
+    #[error("histogram contains no samples")]
+    /// The histogram contains no samples.
+    Empty,
+    #[error("value out of range")]
+    /// The requested value is out of range.
+    OutOfRange,
+}

--- a/histogram/src/histograms/mod.rs
+++ b/histogram/src/histograms/mod.rs
@@ -1,0 +1,217 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::error::HistogramError;
+use crate::AtomicCounter;
+use crate::Counter;
+use crate::Indexing;
+use rustcommon_atomics::{Atomic, Ordering};
+
+/// A histogram type which may be concurrently modified across threads because
+/// it uses atomic counters. All operations are performed using a `Relaxed`
+/// ordering.
+pub struct AtomicHistogram<Value, Count> {
+    buckets: Vec<Count>,
+    exact: Value,
+    max: Value,
+    precision: u8,
+    too_high: Count,
+}
+
+impl<Value, Count> AtomicHistogram<Value, Count>
+where
+    Value: Indexing,
+    Count: AtomicCounter + Default,
+    u64: From<Value> + From<<Count as Atomic>::Primitive>,
+    <Count as Atomic>::Primitive: Copy,
+{
+    /// Create a new atomic histogram. Stores values from 0 to max. Precision
+    /// is used to specify how many significant figures will be preserved.
+    pub fn new(max: Value, precision: u8) -> Self {
+        let precision = Value::constrain_precision(precision);
+        let exact = Value::constrain_exact(max, precision);
+
+        let mut histogram = Self {
+            buckets: Vec::new(),
+            exact,
+            max,
+            precision,
+            too_high: Count::default(),
+        };
+
+        // initialize buckets
+        let max_index = Value::get_index(max, max, exact, precision).unwrap();
+        let mut buckets = Vec::with_capacity(max_index + 1);
+        for _ in 0..=max_index {
+            buckets.push(Count::default());
+        }
+        histogram.buckets = buckets;
+
+        histogram
+    }
+
+    /// Increment the value by the provided count, may saturate the bucket's
+    /// counter.
+    pub fn increment(&self, value: Value, count: <Count as Atomic>::Primitive) {
+        if let Ok(index) = Value::get_index(value, self.max, self.exact, self.precision) {
+            self.buckets[index].fetch_saturating_add(count, Ordering::Relaxed);
+        } else {
+            self.too_high.fetch_saturating_add(count, Ordering::Relaxed);
+        }
+    }
+
+    /// Decrement the value by the provided count, may saturate at zero.
+    pub fn decrement(&self, value: Value, count: <Count as Atomic>::Primitive) {
+        if let Ok(index) = Value::get_index(value, self.max, self.exact, self.precision) {
+            self.buckets[index].fetch_saturating_sub(count, Ordering::Relaxed);
+        } else {
+            self.too_high.fetch_saturating_sub(count, Ordering::Relaxed);
+        }
+    }
+
+    /// Clear all counts
+    pub fn clear(&self) {
+        let default = Count::default().load(Ordering::Relaxed);
+        for i in 0..self.buckets.len() {
+            self.buckets[i].store(default, Ordering::Relaxed);
+        }
+        self.too_high.store(default, Ordering::Relaxed);
+    }
+
+    /// Return the value closest to the specified percentile. Returns an error
+    /// if the value is outside of the histogram range or if the histogram is
+    /// empty.
+    pub fn percentile(&self, percentile: f64) -> Result<Value, HistogramError> {
+        let mut total = 0_u64;
+        for value in self.buckets.iter() {
+            total += u64::from(value.load(Ordering::Relaxed));
+        }
+        total += u64::from(self.too_high.load(Ordering::Relaxed));
+        if total == 0 {
+            return Err(HistogramError::Empty);
+        }
+        let need = if percentile > 0.0 {
+            (percentile * total as f64).ceil() as u64
+        } else {
+            1
+        };
+        let mut have = 0_u64;
+        for i in 0..self.buckets.len() {
+            have += u64::from(self.buckets[i].load(Ordering::Relaxed));
+            if have >= need {
+                return Ok(Value::get_value(
+                    i,
+                    self.buckets.len(),
+                    self.max,
+                    self.exact,
+                    self.precision,
+                )
+                .unwrap());
+            }
+        }
+        Err(HistogramError::OutOfRange)
+    }
+}
+
+/// A histogram type which follows normal ownership rules.
+pub struct Histogram<Value, Count> {
+    buckets: Vec<Count>,
+    exact: Value,
+    max: Value,
+    precision: u8,
+    too_high: Count,
+}
+
+impl<Value, Count> Histogram<Value, Count>
+where
+    Value: Indexing,
+    Count: Counter,
+    u64: From<Value> + From<Count>,
+{
+    /// Create a new histogram. Stores values from 0 to max. Precision is used
+    /// to specify how many significant figures will be preserved.
+    pub fn new(max: Value, precision: u8) -> Self {
+        let precision = Value::constrain_precision(precision);
+        let exact = Value::constrain_exact(max, precision);
+
+        let mut histogram = Self {
+            buckets: Vec::new(),
+            exact,
+            max,
+            precision,
+            too_high: Count::default(),
+        };
+
+        // initialize buckets
+        let max_index = Value::get_index(max, max, exact, precision).unwrap();
+        let mut buckets = Vec::with_capacity(max_index + 1);
+        for _ in 0..=max_index {
+            buckets.push(Count::default());
+        }
+        histogram.buckets = buckets;
+
+        histogram
+    }
+
+    /// Increment the value by the provided count, may saturate the bucket's
+    /// counter.
+    pub fn increment(&mut self, value: Value, count: Count) {
+        if let Ok(index) = Value::get_index(value, self.max, self.exact, self.precision) {
+            self.buckets[index].saturating_add(count);
+        } else {
+            self.too_high.saturating_add(count);
+        }
+    }
+
+    /// Decrement the value by the provided count, may saturate at zero.
+    pub fn decrement(&mut self, value: Value, count: Count) {
+        if let Ok(index) = Value::get_index(value, self.max, self.exact, self.precision) {
+            self.buckets[index].saturating_sub(count);
+        } else {
+            self.too_high.saturating_sub(count);
+        }
+    }
+
+    /// Clear all counts
+    pub fn clear(&mut self) {
+        for i in 0..self.buckets.len() {
+            self.buckets[i] = Count::default();
+        }
+        self.too_high = Count::default();
+    }
+
+    /// Return the value closest to the specified percentile. Returns an error
+    /// if the value is outside of the histogram range or if the histogram is
+    /// empty.
+    pub fn percentile(&self, percentile: f64) -> Result<Value, HistogramError> {
+        let mut total = 0_u64;
+        for value in self.buckets.iter() {
+            total += u64::from(*value);
+        }
+        total += u64::from(self.too_high);
+        if total == 0 {
+            return Err(HistogramError::Empty);
+        }
+        let need = if percentile > 0.0 {
+            (percentile * total as f64).ceil() as u64
+        } else {
+            1
+        };
+        let mut have = 0_u64;
+        for i in 0..self.buckets.len() {
+            have += u64::from(self.buckets[i]);
+            if have >= need {
+                return Ok(Value::get_value(
+                    i,
+                    self.buckets.len(),
+                    self.max,
+                    self.exact,
+                    self.precision,
+                )
+                .unwrap());
+            }
+        }
+        Err(HistogramError::OutOfRange)
+    }
+}

--- a/histogram/src/indexing/mod.rs
+++ b/histogram/src/indexing/mod.rs
@@ -1,0 +1,27 @@
+mod u16;
+mod u32;
+mod u64;
+mod u8;
+
+pub trait Indexing
+where
+    Self: Sized + Copy,
+{
+    fn get_index(value: Self, max: Self, exact: Self, precision: u8) -> Result<usize, ()>;
+    fn get_min_value(
+        index: usize,
+        buckets: usize,
+        max: Self,
+        exact: Self,
+        precision: u8,
+    ) -> Result<Self, ()>;
+    fn get_value(
+        index: usize,
+        buckets: usize,
+        max: Self,
+        exact: Self,
+        precision: u8,
+    ) -> Result<Self, ()>;
+    fn constrain_precision(precision: u8) -> u8;
+    fn constrain_exact(max: Self, precision: u8) -> Self;
+}

--- a/histogram/src/indexing/u16.rs
+++ b/histogram/src/indexing/u16.rs
@@ -1,0 +1,78 @@
+impl crate::Indexing for u16 {
+    fn constrain_precision(precision: u8) -> u8 {
+        if precision == 0 {
+            1
+        } else if precision > 5 {
+            5
+        } else {
+            precision
+        }
+    }
+
+    fn constrain_exact(max: Self, precision: u8) -> Self {
+        if precision == 5 {
+            max
+        } else {
+            10_u16.pow(precision.into())
+        }
+    }
+
+    fn get_index(value: Self, max: Self, exact: Self, precision: u8) -> Result<usize, ()> {
+        if value > max {
+            Err(())
+        } else if value <= exact {
+            Ok(value.into())
+        } else {
+            let power = (value as f64).log10().floor() as u16;
+            let denominator = 10_usize.pow((power - precision as u16 + 1).into());
+            let power_offset =
+                (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;
+            let remainder: usize = value as usize / denominator;
+            let shift = exact as usize / 10;
+            let index = exact as usize + power_offset + remainder - shift;
+            Ok(index)
+        }
+    }
+
+    // Internal function to get the minimum value for a given bucket index
+    fn get_min_value(
+        index: usize,
+        buckets: usize,
+        max: Self,
+        exact: Self,
+        precision: u8,
+    ) -> Result<Self, ()> {
+        if index >= buckets {
+            Err(())
+        } else if (index as u16) <= exact {
+            Ok(index as u16)
+        } else if index == buckets - 1 {
+            Ok(max)
+        } else {
+            let shift = 10_usize.pow((precision - 1).into());
+            let base_offset = 10_usize.pow(precision.into());
+            let power = precision as usize + (index - base_offset) / (9 * shift);
+            let power_offset = (0.9
+                * (10_usize.pow(precision.into()) * (power - precision as usize)) as f64)
+                as usize;
+            let value = (index + shift - base_offset - power_offset) as u16
+                * 10_u16.pow((power - precision as usize + 1) as u32);
+            Ok(value)
+        }
+    }
+
+    // Internal function to get the max value stored in a given bucket
+    fn get_value(
+        index: usize,
+        buckets: usize,
+        max: Self,
+        exact: Self,
+        precision: u8,
+    ) -> Result<Self, ()> {
+        if index == buckets - 1 {
+            Ok(max)
+        } else {
+            Ok(Self::get_min_value(index + 1, buckets, max, exact, precision)? - 1)
+        }
+    }
+}

--- a/histogram/src/indexing/u32.rs
+++ b/histogram/src/indexing/u32.rs
@@ -1,0 +1,78 @@
+impl crate::Indexing for u32 {
+    fn constrain_precision(precision: u8) -> u8 {
+        if precision == 0 {
+            1
+        } else if precision > 10 {
+            10
+        } else {
+            precision
+        }
+    }
+
+    fn constrain_exact(max: Self, precision: u8) -> Self {
+        if precision == 10 {
+            max
+        } else {
+            10_u32.pow(precision.into())
+        }
+    }
+
+    fn get_index(value: Self, max: Self, exact: Self, precision: u8) -> Result<usize, ()> {
+        if value > max {
+            Err(())
+        } else if value <= exact {
+            Ok(value as usize)
+        } else {
+            let power = (value as f64).log10().floor() as u16;
+            let denominator = 10_usize.pow((power - precision as u16 + 1).into());
+            let power_offset =
+                (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;
+            let remainder: usize = value as usize / denominator;
+            let shift = exact as usize / 10;
+            let index = exact as usize + power_offset + remainder - shift;
+            Ok(index)
+        }
+    }
+
+    // Internal function to get the minimum value for a given bucket index
+    fn get_min_value(
+        index: usize,
+        buckets: usize,
+        max: Self,
+        exact: Self,
+        precision: u8,
+    ) -> Result<Self, ()> {
+        if index >= buckets {
+            Err(())
+        } else if (index as u32) <= exact {
+            Ok(index as u32)
+        } else if index == buckets - 1 {
+            Ok(max)
+        } else {
+            let shift = 10_usize.pow((precision - 1).into());
+            let base_offset = 10_usize.pow(precision.into());
+            let power = precision as usize + (index - base_offset) / (9 * shift);
+            let power_offset = (0.9
+                * (10_usize.pow(precision.into()) * (power - precision as usize)) as f64)
+                as usize;
+            let value = (index + shift - base_offset - power_offset) as u32
+                * 10_u32.pow((power - precision as usize + 1) as u32);
+            Ok(value)
+        }
+    }
+
+    // Internal function to get the max value stored in a given bucket
+    fn get_value(
+        index: usize,
+        buckets: usize,
+        max: Self,
+        exact: Self,
+        precision: u8,
+    ) -> Result<Self, ()> {
+        if index == buckets - 1 {
+            Ok(max)
+        } else {
+            Ok(Self::get_min_value(index + 1, buckets, max, exact, precision)? - 1)
+        }
+    }
+}

--- a/histogram/src/indexing/u64.rs
+++ b/histogram/src/indexing/u64.rs
@@ -1,0 +1,78 @@
+impl crate::Indexing for u64 {
+    fn constrain_precision(precision: u8) -> u8 {
+        if precision == 0 {
+            1
+        } else if precision > 20 {
+            20
+        } else {
+            precision
+        }
+    }
+
+    fn constrain_exact(max: Self, precision: u8) -> Self {
+        if precision == 20 {
+            max
+        } else {
+            10_u64.pow(precision.into())
+        }
+    }
+
+    fn get_index(value: Self, max: Self, exact: Self, precision: u8) -> Result<usize, ()> {
+        if value > max {
+            Err(())
+        } else if value <= exact {
+            Ok(value as usize)
+        } else {
+            let power = (value as f64).log10().floor() as u16;
+            let denominator = 10_usize.pow((power - precision as u16 + 1).into());
+            let power_offset =
+                (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;
+            let remainder: usize = value as usize / denominator;
+            let shift = exact as usize / 10;
+            let index = exact as usize + power_offset + remainder - shift;
+            Ok(index)
+        }
+    }
+
+    // Internal function to get the minimum value for a given bucket index
+    fn get_min_value(
+        index: usize,
+        buckets: usize,
+        max: Self,
+        exact: Self,
+        precision: u8,
+    ) -> Result<Self, ()> {
+        if index >= buckets {
+            Err(())
+        } else if (index as u64) <= exact {
+            Ok(index as u64)
+        } else if index == buckets - 1 {
+            Ok(max)
+        } else {
+            let shift = 10_usize.pow((precision - 1).into());
+            let base_offset = 10_usize.pow(precision.into());
+            let power = precision as usize + (index - base_offset) / (9 * shift);
+            let power_offset = (0.9
+                * (10_usize.pow(precision.into()) * (power - precision as usize)) as f64)
+                as usize;
+            let value = (index + shift - base_offset - power_offset) as u64
+                * 10_u64.pow((power - precision as usize + 1) as u32);
+            Ok(value)
+        }
+    }
+
+    // Internal function to get the max value stored in a given bucket
+    fn get_value(
+        index: usize,
+        buckets: usize,
+        max: Self,
+        exact: Self,
+        precision: u8,
+    ) -> Result<Self, ()> {
+        if index == buckets - 1 {
+            Ok(max)
+        } else {
+            Ok(Self::get_min_value(index + 1, buckets, max, exact, precision)? - 1)
+        }
+    }
+}

--- a/histogram/src/indexing/u8.rs
+++ b/histogram/src/indexing/u8.rs
@@ -1,0 +1,78 @@
+impl crate::Indexing for u8 {
+    fn constrain_precision(precision: u8) -> u8 {
+        if precision == 0 {
+            1
+        } else if precision > 3 {
+            3
+        } else {
+            precision
+        }
+    }
+
+    fn constrain_exact(max: Self, precision: u8) -> Self {
+        if precision == 3 {
+            max
+        } else {
+            10_u8.pow(precision.into())
+        }
+    }
+
+    fn get_index(value: Self, max: Self, exact: Self, precision: u8) -> Result<usize, ()> {
+        if value > max {
+            Err(())
+        } else if value <= exact {
+            Ok(value.into())
+        } else {
+            let power = (value as f64).log10().floor() as u8;
+            let denominator = 10_usize.pow((power - precision + 1).into());
+            let power_offset =
+                (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;
+            let remainder: usize = value as usize / denominator;
+            let shift = exact as usize / 10;
+            let index = exact as usize + power_offset + remainder - shift;
+            Ok(index)
+        }
+    }
+
+    // Internal function to get the minimum value for a given bucket index
+    fn get_min_value(
+        index: usize,
+        buckets: usize,
+        max: Self,
+        exact: Self,
+        precision: u8,
+    ) -> Result<Self, ()> {
+        if index >= buckets {
+            Err(())
+        } else if (index as u8) <= exact {
+            Ok(index as u8)
+        } else if index == buckets - 1 {
+            Ok(max)
+        } else {
+            let shift = 10_usize.pow((precision - 1).into());
+            let base_offset = 10_usize.pow(precision.into());
+            let power = precision as usize + (index - base_offset) / (9 * shift);
+            let power_offset = (0.9
+                * (10_usize.pow(precision.into()) * (power - precision as usize)) as f64)
+                as usize;
+            let value = (index + shift - base_offset - power_offset) as u8
+                * 10_u8.pow((power - precision as usize + 1) as u32);
+            Ok(value)
+        }
+    }
+
+    // Internal function to get the max value stored in a given bucket
+    fn get_value(
+        index: usize,
+        buckets: usize,
+        max: Self,
+        exact: Self,
+        precision: u8,
+    ) -> Result<Self, ()> {
+        if index == buckets - 1 {
+            Ok(max)
+        } else {
+            Ok(Self::get_min_value(index + 1, buckets, max, exact, precision)? - 1)
+        }
+    }
+}

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -1,0 +1,35 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+mod bucket;
+mod counter;
+mod error;
+mod histograms;
+mod indexing;
+
+pub use bucket::*;
+pub use counter::*;
+pub use error::*;
+pub use histograms::*;
+pub use indexing::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build() {
+        let h = Histogram::<u8, u8>::new(255, 3);
+        assert_eq!(h.percentile(0.0), Err(HistogramError::Empty));
+
+        let mut h = Histogram::<u16, u8>::new(10000, 3);
+        assert_eq!(h.percentile(0.0), Err(HistogramError::Empty));
+        h.increment(1, 1);
+        assert_eq!(h.percentile(0.0), Ok(1));
+        assert_eq!(h.percentile(1.0), Ok(1));
+        h.increment(65535, 1);
+        assert_eq!(h.percentile(0.0), Ok(1));
+        assert_eq!(h.percentile(1.0), Err(HistogramError::OutOfRange));
+    }
+}


### PR DESCRIPTION
Problem

Current histogram implementation in datastructures crate is focused on
histograms for u64 values. We can expand upon this to provide
histograms which operate on other values and can be either atomic or
non-atomic.

Solution

Adds a dedicated histogram crate with atomic and non-atomic
implementations for u8, u16, u32, and u64 values.
