### PR TITLE
add streamstats for percentiles across a stream of measurements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "logger",
     "metrics",
     "ratelimiter",
+    "streamstats",
     "timer",
     "waterfall",
 ]

--- a/streamstats/Cargo.toml
+++ b/streamstats/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "streamstats"
+version = "0.1.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/streamstats/src/lib.rs
+++ b/streamstats/src/lib.rs
@@ -1,5 +1,4 @@
-
-pub trait Value: Default + Copy + Ord { }
+pub trait Value: Default + Copy + Ord {}
 
 impl Value for u64 {}
 impl Value for u32 {}
@@ -8,86 +7,92 @@ impl Value for u8 {}
 impl Value for usize {}
 
 pub struct Streamstats<T> {
-	buffer: Vec<T>,
-	current: usize,
-	oldest: usize,
+    buffer: Vec<T>,
+    current: usize,
+    oldest: usize,
+    sorted: Vec<T>,
 }
 
 impl<T> Streamstats<T>
-where T: Value
+where
+    T: Value,
 {
-	pub fn new(capacity: usize) -> Self {
-		let mut buffer = Vec::with_capacity(capacity);
-		for _ in 0..capacity {
-			buffer.push(Default::default());
-		}
-		Self {
-			buffer,
-			current: 0,
-			oldest: 0,
-		}
-	}
+    pub fn new(capacity: usize) -> Self {
+        let mut buffer = Vec::with_capacity(capacity);
+        let sorted = buffer.clone();
+        for _ in 0..capacity {
+            buffer.push(Default::default());
+        }
+        Self {
+            buffer,
+            current: 0,
+            oldest: 0,
+            sorted,
+        }
+    }
 
-	pub fn insert(&mut self, value: T) {
-		self.buffer[self.current] = value;
-		self.current += 1;
-		if self.current >= self.buffer.len() {
-			self.current = 0;
-		}
-		if self.current == self.oldest {
-			self.oldest += 1;
-			if self.oldest >= self.buffer.len() {
-				self.oldest = 0;
-			}
-		}
-	}
+    pub fn insert(&mut self, value: T) {
+        self.buffer[self.current] = value;
+        self.current += 1;
+        if self.current >= self.buffer.len() {
+            self.current = 0;
+        }
+        if self.current == self.oldest {
+            self.oldest += 1;
+            if self.oldest >= self.buffer.len() {
+                self.oldest = 0;
+            }
+        }
+        self.sorted.clear(); // resort required
+    }
 
-	fn values(&self) -> usize {
-		if self.current < self.oldest {
-			(self.current + self.buffer.len()) - self.oldest
-		} else if self.current == self.oldest {
-			0
-		} else {
-			self.current - self.oldest
-		}
-	}
+    fn values(&self) -> usize {
+        if self.current < self.oldest {
+            (self.current + self.buffer.len()) - self.oldest
+        } else if self.current == self.oldest {
+            0
+        } else {
+            self.current - self.oldest
+        }
+    }
 
-	pub fn percentile(&self, percentile: f64) -> Option<T> {
-		let values = self.values();
-		if values == 0 {
-			None
-		} else {
-			let mut tmp = Vec::with_capacity(values);
-			if self.current > self.oldest {
-				for i in self.oldest..self.current {
-					tmp.push(self.buffer[i]);
-				}
-			} else {
-				for i in self.oldest..self.buffer.len() {
-					tmp.push(self.buffer[i]);
-				}
-				for i in 0..self.current {
-					tmp.push(self.buffer[i]);
-				}
-			}
-			tmp.sort();
-			if percentile == 0.0 {
-				Some(tmp[0])
-			} else {
-				let need = (percentile * values as f64).ceil() as usize;
-				Some(tmp[need - 1])
-			}
-		}
-	}
+    pub fn percentile(&mut self, percentile: f64) -> Option<T> {
+        if self.sorted.len() == 0 {
+            let values = self.values();
+            if values == 0 {
+                return None;
+            } else {
+                if self.current > self.oldest {
+                    for i in self.oldest..self.current {
+                        self.sorted.push(self.buffer[i]);
+                    }
+                } else {
+                    for i in self.oldest..self.buffer.len() {
+                        self.sorted.push(self.buffer[i]);
+                    }
+                    for i in 0..self.current {
+                        self.sorted.push(self.buffer[i]);
+                    }
+                }
+                self.sorted.sort();
+            }
+        }
+        if percentile == 0.0 {
+            Some(self.sorted[0])
+        } else {
+            let need = (percentile * self.sorted.len() as f64).ceil() as usize;
+            Some(self.sorted[need - 1])
+        }
+    }
 
-	pub fn clear(&mut self) {
-		self.oldest = self.current;
-	}
+    pub fn clear(&mut self) {
+        self.oldest = self.current;
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
     #[test]
     fn basic() {
@@ -96,9 +101,9 @@ mod tests {
         streamstats.insert(1);
         assert_eq!(streamstats.percentile(0.0), Some(1));
         streamstats.clear();
-        for i in 0..=1_000_000 {
-        	streamstats.insert(i);
-        	assert_eq!(streamstats.percentile(1.0), Some(i));
+        for i in 0..=10_000 {
+            streamstats.insert(i);
+            assert_eq!(streamstats.percentile(1.0), Some(i));
         }
     }
 }

--- a/streamstats/src/lib.rs
+++ b/streamstats/src/lib.rs
@@ -87,6 +87,7 @@ where
 
     pub fn clear(&mut self) {
         self.oldest = self.current;
+        self.sorted.clear();
     }
 }
 

--- a/streamstats/src/lib.rs
+++ b/streamstats/src/lib.rs
@@ -102,6 +102,8 @@ mod tests {
         streamstats.insert(1);
         assert_eq!(streamstats.percentile(0.0), Some(1));
         streamstats.clear();
+        assert_eq!(streamstats.percentile(0.0), None);
+
         for i in 0..=10_000 {
             streamstats.insert(i);
             assert_eq!(streamstats.percentile(1.0), Some(i));

--- a/streamstats/src/lib.rs
+++ b/streamstats/src/lib.rs
@@ -1,0 +1,104 @@
+
+pub trait Value: Default + Copy + Ord { }
+
+impl Value for u64 {}
+impl Value for u32 {}
+impl Value for u16 {}
+impl Value for u8 {}
+impl Value for usize {}
+
+pub struct Streamstats<T> {
+	buffer: Vec<T>,
+	current: usize,
+	oldest: usize,
+}
+
+impl<T> Streamstats<T>
+where T: Value
+{
+	pub fn new(capacity: usize) -> Self {
+		let mut buffer = Vec::with_capacity(capacity);
+		for _ in 0..capacity {
+			buffer.push(Default::default());
+		}
+		Self {
+			buffer,
+			current: 0,
+			oldest: 0,
+		}
+	}
+
+	pub fn insert(&mut self, value: T) {
+		self.buffer[self.current] = value;
+		self.current += 1;
+		if self.current >= self.buffer.len() {
+			self.current = 0;
+		}
+		if self.current == self.oldest {
+			self.oldest += 1;
+			if self.oldest >= self.buffer.len() {
+				self.oldest = 0;
+			}
+		}
+	}
+
+	fn values(&self) -> usize {
+		if self.current < self.oldest {
+			(self.current + self.buffer.len()) - self.oldest
+		} else if self.current == self.oldest {
+			0
+		} else {
+			self.current - self.oldest
+		}
+	}
+
+	pub fn percentile(&self, percentile: f64) -> Option<T> {
+		let values = self.values();
+		if values == 0 {
+			None
+		} else {
+			let mut tmp = Vec::with_capacity(values);
+			if self.current > self.oldest {
+				for i in self.oldest..self.current {
+					tmp.push(self.buffer[i]);
+				}
+			} else {
+				for i in self.oldest..self.buffer.len() {
+					tmp.push(self.buffer[i]);
+				}
+				for i in 0..self.current {
+					tmp.push(self.buffer[i]);
+				}
+			}
+			tmp.sort();
+			if percentile == 0.0 {
+				Some(tmp[0])
+			} else {
+				let need = (percentile * values as f64).ceil() as usize;
+				Some(tmp[need - 1])
+			}
+		}
+	}
+
+	pub fn clear(&mut self) {
+		self.oldest = self.current;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+    #[test]
+    fn basic() {
+        let mut streamstats = Streamstats::<u64>::new(1000);
+        assert_eq!(streamstats.percentile(0.0), None);
+        streamstats.insert(1);
+        assert_eq!(streamstats.percentile(0.0), Some(1));
+        streamstats.clear();
+        for i in 0..=1_000_000 {
+        	streamstats.insert(i);
+        	assert_eq!(streamstats.percentile(1.0), Some(i));
+        }
+    }
+}


### PR DESCRIPTION
Problem

Histograms can be space inefficient for calculating percentiles
across a set of measurements when minimal lookback is required.
The current implementation in `datastructures` keeps a buffer of
values seen so they can be removed later in addition to the actual
histogram bucket storage.

For u64 values and counters, this is ~50kB of bucket storage plus
16B (timestamp) + 8B (value) + 8B (count) + 8B (direction) => 40B
per value in history.

Alternatively, we can maintain a ring buffer of values, and a sorted
buffer for calculating percentiles. For u64 values, this is 16B per
value. We could even include a timestamp and stay at 32B per value
in history, keeping the footprint much less than the histogram
approach.

Solution

Adds a new crate that allows calculating a percentile from a ring
buffer of previous measurements. This could be useful for providing
percentiles of instantaneous observations / gauge readings.

This has a lower memory footprint for cases where there are a limited
number of observations that need to be tracked. The tradeoff is that
calculating the percentile requires sorting a vector of measurements.
This sorted buffer is cached so sorting cost is amortized between
percentile calculations when there are no new values recorded
between calculations. This also keeps memory footprint fixed.

Result

New library which can be integrated into other libraries.
