### PR TITLE
metrics2: adds a WIP metrics library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "histogram",
     "logger",
     "metrics",
+    "metrics2",
     "ratelimiter",
     "streamstats",
     "timer",

--- a/heatmap/src/lib.rs
+++ b/heatmap/src/lib.rs
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_atomics::*;
-use rustcommon_histogram::*;
+pub use rustcommon_atomics::*;
+pub use rustcommon_histogram::{Indexing, Counter, AtomicCounter, HistogramError};
+use rustcommon_histogram::{AtomicHistogram, Histogram};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 

--- a/heatmap/src/lib.rs
+++ b/heatmap/src/lib.rs
@@ -3,7 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 pub use rustcommon_atomics::*;
-pub use rustcommon_histogram::{Indexing, Counter, AtomicCounter, HistogramError};
+pub use rustcommon_histogram::{AtomicCounter, Counter, HistogramError, Indexing};
 use rustcommon_histogram::{AtomicHistogram, Histogram};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};

--- a/histogram/src/indexing/mod.rs
+++ b/histogram/src/indexing/mod.rs
@@ -1,3 +1,7 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 mod u16;
 mod u32;
 mod u64;

--- a/histogram/src/indexing/u16.rs
+++ b/histogram/src/indexing/u16.rs
@@ -1,3 +1,7 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 impl crate::Indexing for u16 {
     fn constrain_precision(precision: u8) -> u8 {
         if precision == 0 {
@@ -84,5 +88,163 @@ impl crate::Indexing for u16 {
         precision: u8,
     ) -> Result<Self, ()> {
         Self::get_value(index, buckets, max, exact, precision).map(|v| v + 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Indexing;
+
+    #[test]
+    fn get_index_p1() {
+        let precision = 1;
+        let max = u16::MAX;
+        let exact = u16::constrain_exact(max, precision);
+        for i in 0..(10_u16.pow(precision.into())) {
+            assert_eq!(u16::get_index(i, max, exact, precision), Ok(i as usize));
+        }
+        for i in 1..10 {
+            for j in 0..10 {
+                let v = i * 10 + j;
+                assert_eq!(u16::get_index(v, max, exact, precision), Ok(9 + i as usize));
+            }
+        }
+        for i in 1..10 {
+            for j in 0..100 {
+                let v = i * 100 + j;
+                assert_eq!(
+                    u16::get_index(v, max, exact, precision),
+                    Ok(18 + i as usize)
+                );
+            }
+        }
+        for i in 1..10 {
+            for j in 0..1000 {
+                let v = i * 1000 + j;
+                assert_eq!(
+                    u16::get_index(v, max, exact, precision),
+                    Ok(27 + i as usize)
+                );
+            }
+        }
+        for i in 1..6 {
+            for j in 0..10000 {
+                let v = i * 10000 + j;
+                assert_eq!(
+                    u16::get_index(v, max, exact, precision),
+                    Ok(36 + i as usize)
+                );
+            }
+        }
+        for j in 0..5536 {
+            let v = 60000 + j;
+            assert_eq!(u16::get_index(v, max, exact, precision), Ok(42 as usize));
+        }
+    }
+
+    #[test]
+    fn get_index_p2() {
+        let precision = 2;
+        let max = u16::MAX;
+        let exact = u16::constrain_exact(max, precision);
+        for i in 0..(10_u16.pow(precision.into())) {
+            assert_eq!(u16::get_index(i, max, exact, precision), Ok(i as usize));
+        }
+        for i in 10..100 {
+            for j in 0..10 {
+                let v = i * 10 + j;
+                assert_eq!(
+                    u16::get_index(v, max, exact, precision),
+                    Ok(90 + i as usize)
+                );
+            }
+        }
+        for i in 10..100 {
+            for j in 0..100 {
+                let v = i * 100 + j;
+                assert_eq!(
+                    u16::get_index(v, max, exact, precision),
+                    Ok(180 + i as usize)
+                );
+            }
+        }
+        for i in 10..65 {
+            for j in 0..1000 {
+                let v = i * 1000 + j;
+                assert_eq!(
+                    u16::get_index(v, max, exact, precision),
+                    Ok(270 + i as usize)
+                );
+            }
+        }
+        for j in 0..536 {
+            let v = 65000 + j;
+            assert_eq!(u16::get_index(v, max, exact, precision), Ok(335 as usize));
+        }
+    }
+
+    #[test]
+    fn get_index_p3() {
+        let precision = 3;
+        let max = u16::MAX;
+        let exact = u16::constrain_exact(max, precision);
+        for i in 0..(10_u16.pow(precision.into())) {
+            assert_eq!(u16::get_index(i, max, exact, precision), Ok(i as usize));
+        }
+        for i in 100..1000 {
+            for j in 0..10 {
+                let v = i * 10 + j;
+                assert_eq!(
+                    u16::get_index(v, max, exact, precision),
+                    Ok(900 + i as usize)
+                );
+            }
+        }
+        for i in 100..655 {
+            for j in 0..100 {
+                let v = i * 100 + j;
+                assert_eq!(
+                    u16::get_index(v, max, exact, precision),
+                    Ok(1800 + i as usize)
+                );
+            }
+        }
+        for j in 0..36 {
+            let v = 65500 + j;
+            assert_eq!(u16::get_index(v, max, exact, precision), Ok(2455 as usize));
+        }
+    }
+
+    #[test]
+    fn get_index_p4() {
+        let precision = 4;
+        let max = u16::MAX;
+        let exact = u16::constrain_exact(max, precision);
+        for i in 0..(10_u16.pow(precision.into())) {
+            assert_eq!(u16::get_index(i, max, exact, precision), Ok(i as usize));
+        }
+        for i in 1000..6553 {
+            for j in 0..10 {
+                let v = i * 10 + j;
+                assert_eq!(
+                    u16::get_index(v, max, exact, precision),
+                    Ok(9000 + i as usize)
+                );
+            }
+        }
+        for j in 0..6 {
+            let v = 65530 + j;
+            assert_eq!(u16::get_index(v, max, exact, precision), Ok(15553 as usize));
+        }
+    }
+
+    #[test]
+    fn get_index_p5() {
+        let precision = 5;
+        let max = u16::MAX;
+        let exact = u16::constrain_exact(max, precision);
+        for v in 0..max {
+            assert_eq!(u16::get_index(v, max, exact, precision), Ok(v as usize));
+        }
     }
 }

--- a/metrics2/Cargo.toml
+++ b/metrics2/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "metrics2"
+version = "0.0.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+edition = "2018"
+
+[dependencies]
+dashmap = "3.11.4"
+rustcommon-heatmap = { path = "../heatmap" }
+rustcommon-streamstats = { path = "../streamstats" }

--- a/metrics2/src/lib.rs
+++ b/metrics2/src/lib.rs
@@ -1,0 +1,428 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use core::ops::Sub;
+use rustcommon_streamstats::AtomicStreamstats;
+use std::sync::RwLock;
+use std::time::Duration;
+use std::time::Instant;
+use dashmap::DashMap;
+
+use rustcommon_heatmap::*;
+
+pub trait Value: Atomic + Default {}
+pub trait Count: Atomic + Default + AtomicCounter {}
+pub trait Primitive: Ord + Indexing + Copy + From<u8> + Sub<Self, Output = Self> + FloatConvert {}
+
+impl Primitive for u8 {}
+impl Primitive for u16 {}
+impl Primitive for u32 {}
+impl Primitive for u64 {}
+
+impl Count for AtomicU8 {}
+impl Count for AtomicU16 {}
+impl Count for AtomicU32 {}
+impl Count for AtomicU64 {}
+
+impl Value for AtomicU8 {}
+impl Value for AtomicU16 {}
+impl Value for AtomicU32 {}
+impl Value for AtomicU64 {}
+
+/// A collection of channels which each record measurements for a corresponding
+/// `Statistic`. It is designed for concurrent access, making it useful for
+/// providing a unified metrics library for multi-threaded applications.
+pub struct Metrics<Value, Count>
+where
+	Value: crate::Value,
+	Count: crate::Count,
+	<Value as Atomic>::Primitive: Primitive,
+	<Count as Atomic>::Primitive: Primitive,
+	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+	channels: DashMap<String, Channel<Value, Count>>,
+}
+
+impl<Value, Count> Metrics<Value, Count>
+where
+	Value: crate::Value,
+	Count: crate::Count,
+	<Value as Atomic>::Primitive: Primitive,
+	<Count as Atomic>::Primitive: Primitive,
+	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+	/// Create a new empty metrics registry
+	pub fn new() -> Self {
+		Self {
+			channels: DashMap::new(),
+		}
+	}
+
+	/// Register a new statistic.
+	pub fn register(&self, statistic: &dyn Statistic<Value, Count>) {
+		if !self.channels.contains_key(statistic.name()) {
+			let channel = Channel::new(statistic);
+			self.channels.insert(statistic.name().to_string(), channel);
+		}
+	}
+
+	/// Record a bucket value + count pair for distribution based statistics.
+	pub fn record_bucket(&self, statistic: &dyn Statistic<Value, Count>, time: Instant, value: <Value as Atomic>::Primitive, count: <Count as Atomic>::Primitive) -> Result<(), ()> {
+		if statistic.source() == Source::Distribution {
+			if let Some(channel) = self.channels.get(statistic.name()) {
+				channel.record_bucket(time, value, count)
+			} else {
+				// statistic not registered
+				Err(())
+			}
+		} else {
+			// source mismatch
+			Err(())
+		}
+	}
+
+	/// Record a counter observation for counter based statistics.
+	pub fn record_counter(&self, statistic: &dyn Statistic<Value, Count>, time: Instant, value: <Value as Atomic>::Primitive) -> Result<(), ()> {
+		if statistic.source() == Source::Counter {
+			if let Some(channel) = self.channels.get(statistic.name()) {
+				channel.record_counter(time, value);
+				Ok(())
+			} else {
+				// statistic not registered
+				Err(())
+			}
+		} else {
+			// source mismatch
+			Err(())
+		}
+	}
+
+	/// Record a gauge observation for gauge based statistics.
+	pub fn record_gauge(&self, statistic: &dyn Statistic<Value, Count>, time: Instant, value: <Value as Atomic>::Primitive) -> Result<(), ()> {
+		if statistic.source() == Source::Gauge {
+			if let Some(channel) = self.channels.get(statistic.name()) {
+				channel.record_gauge(time, value);
+				Ok(())
+			} else {
+				// statistic not registered
+				Err(())
+			}
+		} else {
+			// source mismatch
+			Err(())
+		}
+	}
+
+	/// Return a percentile for the given statistic. For counters, it is the
+	/// percentile of secondly rates across the summary. For gauges, it is the
+	/// percentile of gauge readings observed across the summary. For
+	/// distributions it is the percentile across the configured summary.
+	pub fn percentile(&self, statistic: &dyn Statistic<Value, Count>, percentile: f64) -> Result<<Value as Atomic>::Primitive, ()> {
+		if let Some(channel) = self.channels.get(statistic.name()) {
+			channel.percentile(percentile).map_err(|_| ())
+		} else {
+			Err(())
+		}
+	}
+
+	/// Return the reading for the statistic. For counters and gauges, this is
+	/// the most recent measurement recorded.
+	// TODO: decide on how to handle distribution channels 
+	pub fn reading(&self, statistic: &dyn Statistic<Value, Count>) -> Result<<Value as Atomic>::Primitive, ()> {
+		if let Some(channel) = self.channels.get(statistic.name()) {
+			channel.reading()
+		} else {
+			Err(())
+		}
+	}
+}
+
+#[derive(PartialEq, Copy, Clone)]
+pub enum Source {
+	/// Indicates that the source is a monotonically incrementing count.
+	Counter,
+	/// Indicates that the source is an instantaneous gauge reading.
+	Gauge,
+	/// Indicates that the source is an underlying distribution (histogram).
+	Distribution,
+}
+
+pub trait Statistic<Value, Count>
+where
+	Value: crate::Value,
+	Count: crate::Count,
+	<Value as Atomic>::Primitive: Primitive,
+	<Count as Atomic>::Primitive: Primitive,
+	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+	/// The name is used to lookup the channel for the statistic and should be
+	/// unique for each statistic.
+	fn name(&self) -> &str;
+	/// Indicates which source type the statistic tracks.
+	fn source(&self) -> Source;
+	/// Optionally, specify a summary type which is used to produce percentiles.
+	fn summary(&self) -> Option<Summary<Value, Count>> {
+		None
+	}
+}
+
+/// Internal type which stores fields necessary to track a corresponding
+/// statistic.
+struct Channel<Value, Count>
+where
+	Value: crate::Value,
+	Count: crate::Count,
+	<Value as Atomic>::Primitive: Primitive,
+	<Count as Atomic>::Primitive: Primitive,
+	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+	refreshed: RwLock<Instant>,
+	empty: AtomicBool,
+	reading: Value,
+	summary: Option<SummaryType<Value, Count>>,
+}
+
+impl<Value, Count> Channel<Value, Count>
+where
+	Value: crate::Value,
+	Count: crate::Count,
+	<Value as Atomic>::Primitive: Primitive,
+	<Count as Atomic>::Primitive: Primitive,
+	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+	/// Creates an empty channel for a statistic.
+	fn new(statistic: &dyn Statistic<Value, Count>) -> Self {
+		let summary = statistic.summary().map(|v| v.inner);
+		Self {
+			empty: AtomicBool::new(true),
+			reading: Default::default(),
+			refreshed: RwLock::new(Instant::now()),
+			summary,
+		}
+	}
+
+	/// Records a bucket value + count pair into the summary.
+	fn record_bucket(&self, time: Instant, value: <Value as Atomic>::Primitive, count: <Count as Atomic>::Primitive) -> Result<(), ()> {
+		if let Some(summary) = &self.summary {
+			summary.increment(time, value, count);
+			Ok(())
+		} else {
+			Err(())
+		}
+	}
+
+	fn record_counter(&self, time: Instant, value: <Value as Atomic>::Primitive) {
+		if !self.empty.load(Ordering::Relaxed) {
+			if let Some(summary) = &self.summary {
+				let t0 = self.refreshed.write().unwrap();
+				let v0 = self.reading.load(Ordering::Relaxed);
+				let dt = time - *t0;
+				let dv = (value - v0).to_float();
+				let rate = (dv / (dt.as_secs() as f64 + dt.subsec_nanos() as f64 / 1_000_000_000.0)).ceil();
+				summary.increment(time, <Value as Atomic>::Primitive::from_float(rate), 1_u8.into());
+			}
+			self.reading.store(value, Ordering::Relaxed);
+		} else {
+			self.reading.store(value, Ordering::Relaxed);
+			self.empty.store(false, Ordering::Relaxed);
+		}
+	}
+
+	fn record_gauge(&self, time: Instant, value: <Value as Atomic>::Primitive) {
+		if let Some(summary) = &self.summary {
+			summary.increment(time, value, 1_u8.into());
+		}
+		self.reading.store(value, Ordering::Relaxed);
+		if self.empty.load(Ordering::Relaxed) {
+			self.empty.store(false, Ordering::Relaxed);
+		}
+	}
+
+	fn percentile(&self, percentile: f64) -> Result<<Value as Atomic>::Primitive, ()> {
+		if let Some(summary) = &self.summary {
+			summary.percentile(percentile).map_err(|_| ())
+		} else {
+			Err(())
+		}
+	}
+
+	fn reading(&self) -> Result<<Value as Atomic>::Primitive, ()> {
+		if !self.empty.load(Ordering::Relaxed) {
+			Ok(self.reading.load(Ordering::Relaxed))
+		} else {
+			Err(())
+		}
+	}
+}
+
+pub trait FloatConvert {
+	fn to_float(self) -> f64;
+	fn from_float(value: f64) -> Self;
+}
+
+impl FloatConvert for u64 {
+	fn to_float(self) -> f64 {
+		self as f64
+	}
+	fn from_float(value: f64) -> Self {
+		value as Self
+	}
+}
+
+impl FloatConvert for u32 {
+	fn to_float(self) -> f64 {
+		self as f64
+	}
+	fn from_float(value: f64) -> Self {
+		value as Self
+	}
+}
+
+impl FloatConvert for u16 {
+	fn to_float(self) -> f64 {
+		self as f64
+	}
+	fn from_float(value: f64) -> Self {
+		value as Self
+	}
+}
+
+impl FloatConvert for u8 {
+	fn to_float(self) -> f64 {
+		self as f64
+	}
+	fn from_float(value: f64) -> Self {
+		value as Self
+	}
+}
+
+/// Specifies what type of structure should be used for producing summary
+/// metrics. Heatmaps are ideal for data that is sourced from histograms.
+/// Streams are intended for use with data sourced from a counter / gauge and
+/// generally use less memory than a heatmap would unless the range is small and
+/// update frequency is very high. For example, for 60 one second windows, a
+/// heatmap will use approximately 305kB to store values from 0-1billion with
+/// 2 significant figures preserved. This is regardless of the total number of
+/// value + count pairs recorded. Conversely, a stream summary requires about
+/// 16B per stored value. This would mean that until about 325 samples/s with a
+/// 60s window, the stream will use less memory. For 1 sample/s, a stream will
+/// use only ~1kB instead of the ~305kB required to maintain a heatmap. If 3
+/// significant figures are required, a counter would need to be stored about
+/// 3250 times per second for a heatmap to make sense.  
+pub struct Summary<Value, Count>
+where
+	Value: crate::Value,
+	Count: crate::Count,
+	<Value as Atomic>::Primitive: Primitive,
+	<Count as Atomic>::Primitive: Primitive,
+	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+	inner: SummaryType<Value, Count>,
+}
+
+impl<Value, Count> Summary<Value, Count>
+where
+	Value: crate::Value,
+	Count: crate::Count,
+	<Value as Atomic>::Primitive: Primitive,
+	<Count as Atomic>::Primitive: Primitive,
+	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+	/// Specify a heatmap summary will be used. Ideal for data sourced from
+	/// histograms.
+	pub fn heatmap(max: <Value as Atomic>::Primitive, precision: u8, windows: usize, resolution: Duration) -> Summary<Value, Count> {
+		Summary {
+			inner: SummaryType::Heatmap(AtomicHeatmap::<<Value as Atomic>::Primitive, Count>::new(max, precision, windows, resolution))
+		}
+	}
+
+	/// Specify that a stream summary will be used. Stores exactly capacity
+	/// previous values. 
+	pub fn stream(capacity: usize) -> Summary<Value, Count> {
+		Summary {
+			inner: SummaryType::Stream(AtomicStreamstats::<Value>::new(capacity))
+		}
+	}
+}
+
+enum SummaryType<Value, Count>
+where
+	Value: crate::Value,
+	Count: crate::Count,
+	<Value as Atomic>::Primitive: Primitive,
+	<Count as Atomic>::Primitive: Primitive,
+	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+	Heatmap(AtomicHeatmap<<Value as Atomic>::Primitive, Count>),
+	Stream(AtomicStreamstats<Value>),
+}
+
+impl<Value, Count> SummaryType<Value, Count>
+where
+	Value: crate::Value,
+	Count: crate::Count,
+	<Value as Atomic>::Primitive: Primitive,
+	<Count as Atomic>::Primitive: Primitive,
+	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+	fn increment(&self, time: Instant, value: <Value as Atomic>::Primitive, count: <Count as Atomic>::Primitive) {
+		match self {
+			Self::Heatmap(heatmap) => heatmap.increment(time, value, count),
+			Self::Stream(stream) => stream.insert(value),
+		}
+	}
+
+	fn percentile(&self, percentile: f64) -> Result<<Value as Atomic>::Primitive, ()> {
+		match self {
+			Self::Heatmap(heatmap) => heatmap.percentile(percentile).map_err(|_| ()),
+			Self::Stream(stream) => stream.percentile(percentile).map_err(|_| ()),
+		}
+	}
+}
+
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	enum TestStat {
+		Alpha
+	}
+
+	impl Statistic<AtomicU64, AtomicU64> for TestStat {
+		fn name(&self) -> &str {
+			match self {
+				Self::Alpha => "alpha",
+			}
+		}
+
+		fn source(&self) -> Source {
+			match self {
+				Self::Alpha => Source::Counter,
+			}
+		}
+
+		fn summary(&self) -> Option<Summary<AtomicU64, AtomicU64>> {
+			match self {
+				Self::Alpha => Some(Summary::stream(1000)),
+			}
+		}
+	}
+
+    #[test]
+    fn basic() {
+    	let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+    	metrics.register(&TestStat::Alpha);
+    	assert!(metrics.reading(&TestStat::Alpha).is_err());
+    	metrics.record_counter(&TestStat::Alpha, Instant::now(), 0).expect("failed to record counter");
+    	assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
+    	let now = Instant::now();
+    	metrics.record_counter(&TestStat::Alpha, now, 0).expect("failed to record counter");
+    	assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
+    	assert_eq!(metrics.percentile(&TestStat::Alpha, 0.0), Ok(0));
+    	metrics.record_counter(&TestStat::Alpha, now + Duration::from_millis(1000), 1).expect("failed to record counter");
+    	assert_eq!(metrics.reading(&TestStat::Alpha), Ok(1));
+    	assert_eq!(metrics.percentile(&TestStat::Alpha, 100.0), Ok(1));
+    }
+}

--- a/metrics2/src/lib.rs
+++ b/metrics2/src/lib.rs
@@ -3,17 +3,20 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use core::ops::Sub;
+use dashmap::DashMap;
 use rustcommon_streamstats::AtomicStreamstats;
 use std::sync::RwLock;
 use std::time::Duration;
 use std::time::Instant;
-use dashmap::DashMap;
 
 use rustcommon_heatmap::*;
 
 pub trait Value: Atomic + Default {}
 pub trait Count: Atomic + Default + AtomicCounter {}
-pub trait Primitive: Ord + Indexing + Copy + From<u8> + Sub<Self, Output = Self> + FloatConvert {}
+pub trait Primitive:
+    Ord + Indexing + Copy + From<u8> + Sub<Self, Output = Self> + FloatConvert
+{
+}
 
 impl Primitive for u8 {}
 impl Primitive for u16 {}
@@ -35,266 +38,300 @@ impl Value for AtomicU64 {}
 /// providing a unified metrics library for multi-threaded applications.
 pub struct Metrics<Value, Count>
 where
-	Value: crate::Value,
-	Count: crate::Count,
-	<Value as Atomic>::Primitive: Primitive,
-	<Count as Atomic>::Primitive: Primitive,
-	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
-	channels: DashMap<String, Channel<Value, Count>>,
+    channels: DashMap<String, Channel<Value, Count>>,
 }
 
 impl<Value, Count> Metrics<Value, Count>
 where
-	Value: crate::Value,
-	Count: crate::Count,
-	<Value as Atomic>::Primitive: Primitive,
-	<Count as Atomic>::Primitive: Primitive,
-	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
-	/// Create a new empty metrics registry
-	pub fn new() -> Self {
-		Self {
-			channels: DashMap::new(),
-		}
-	}
+    /// Create a new empty metrics registry
+    pub fn new() -> Self {
+        Self {
+            channels: DashMap::new(),
+        }
+    }
 
-	/// Register a new statistic.
-	pub fn register(&self, statistic: &dyn Statistic<Value, Count>) {
-		if !self.channels.contains_key(statistic.name()) {
-			let channel = Channel::new(statistic);
-			self.channels.insert(statistic.name().to_string(), channel);
-		}
-	}
+    /// Register a new statistic.
+    pub fn register(&self, statistic: &dyn Statistic<Value, Count>) {
+        if !self.channels.contains_key(statistic.name()) {
+            let channel = Channel::new(statistic);
+            self.channels.insert(statistic.name().to_string(), channel);
+        }
+    }
 
-	/// Record a bucket value + count pair for distribution based statistics.
-	pub fn record_bucket(&self, statistic: &dyn Statistic<Value, Count>, time: Instant, value: <Value as Atomic>::Primitive, count: <Count as Atomic>::Primitive) -> Result<(), ()> {
-		if statistic.source() == Source::Distribution {
-			if let Some(channel) = self.channels.get(statistic.name()) {
-				channel.record_bucket(time, value, count)
-			} else {
-				// statistic not registered
-				Err(())
-			}
-		} else {
-			// source mismatch
-			Err(())
-		}
-	}
+    /// Record a bucket value + count pair for distribution based statistics.
+    pub fn record_bucket(
+        &self,
+        statistic: &dyn Statistic<Value, Count>,
+        time: Instant,
+        value: <Value as Atomic>::Primitive,
+        count: <Count as Atomic>::Primitive,
+    ) -> Result<(), ()> {
+        if statistic.source() == Source::Distribution {
+            if let Some(channel) = self.channels.get(statistic.name()) {
+                channel.record_bucket(time, value, count)
+            } else {
+                // statistic not registered
+                Err(())
+            }
+        } else {
+            // source mismatch
+            Err(())
+        }
+    }
 
-	/// Record a counter observation for counter based statistics.
-	pub fn record_counter(&self, statistic: &dyn Statistic<Value, Count>, time: Instant, value: <Value as Atomic>::Primitive) -> Result<(), ()> {
-		if statistic.source() == Source::Counter {
-			if let Some(channel) = self.channels.get(statistic.name()) {
-				channel.record_counter(time, value);
-				Ok(())
-			} else {
-				// statistic not registered
-				Err(())
-			}
-		} else {
-			// source mismatch
-			Err(())
-		}
-	}
+    /// Record a counter observation for counter based statistics.
+    pub fn record_counter(
+        &self,
+        statistic: &dyn Statistic<Value, Count>,
+        time: Instant,
+        value: <Value as Atomic>::Primitive,
+    ) -> Result<(), ()> {
+        if statistic.source() == Source::Counter {
+            if let Some(channel) = self.channels.get(statistic.name()) {
+                channel.record_counter(time, value);
+                Ok(())
+            } else {
+                // statistic not registered
+                Err(())
+            }
+        } else {
+            // source mismatch
+            Err(())
+        }
+    }
 
-	/// Record a gauge observation for gauge based statistics.
-	pub fn record_gauge(&self, statistic: &dyn Statistic<Value, Count>, time: Instant, value: <Value as Atomic>::Primitive) -> Result<(), ()> {
-		if statistic.source() == Source::Gauge {
-			if let Some(channel) = self.channels.get(statistic.name()) {
-				channel.record_gauge(time, value);
-				Ok(())
-			} else {
-				// statistic not registered
-				Err(())
-			}
-		} else {
-			// source mismatch
-			Err(())
-		}
-	}
+    /// Record a gauge observation for gauge based statistics.
+    pub fn record_gauge(
+        &self,
+        statistic: &dyn Statistic<Value, Count>,
+        time: Instant,
+        value: <Value as Atomic>::Primitive,
+    ) -> Result<(), ()> {
+        if statistic.source() == Source::Gauge {
+            if let Some(channel) = self.channels.get(statistic.name()) {
+                channel.record_gauge(time, value);
+                Ok(())
+            } else {
+                // statistic not registered
+                Err(())
+            }
+        } else {
+            // source mismatch
+            Err(())
+        }
+    }
 
-	/// Return a percentile for the given statistic. For counters, it is the
-	/// percentile of secondly rates across the summary. For gauges, it is the
-	/// percentile of gauge readings observed across the summary. For
-	/// distributions it is the percentile across the configured summary.
-	pub fn percentile(&self, statistic: &dyn Statistic<Value, Count>, percentile: f64) -> Result<<Value as Atomic>::Primitive, ()> {
-		if let Some(channel) = self.channels.get(statistic.name()) {
-			channel.percentile(percentile).map_err(|_| ())
-		} else {
-			Err(())
-		}
-	}
+    /// Return a percentile for the given statistic. For counters, it is the
+    /// percentile of secondly rates across the summary. For gauges, it is the
+    /// percentile of gauge readings observed across the summary. For
+    /// distributions it is the percentile across the configured summary.
+    pub fn percentile(
+        &self,
+        statistic: &dyn Statistic<Value, Count>,
+        percentile: f64,
+    ) -> Result<<Value as Atomic>::Primitive, ()> {
+        if let Some(channel) = self.channels.get(statistic.name()) {
+            channel.percentile(percentile).map_err(|_| ())
+        } else {
+            Err(())
+        }
+    }
 
-	/// Return the reading for the statistic. For counters and gauges, this is
-	/// the most recent measurement recorded.
-	// TODO: decide on how to handle distribution channels 
-	pub fn reading(&self, statistic: &dyn Statistic<Value, Count>) -> Result<<Value as Atomic>::Primitive, ()> {
-		if let Some(channel) = self.channels.get(statistic.name()) {
-			channel.reading()
-		} else {
-			Err(())
-		}
-	}
+    /// Return the reading for the statistic. For counters and gauges, this is
+    /// the most recent measurement recorded.
+    // TODO: decide on how to handle distribution channels
+    pub fn reading(
+        &self,
+        statistic: &dyn Statistic<Value, Count>,
+    ) -> Result<<Value as Atomic>::Primitive, ()> {
+        if let Some(channel) = self.channels.get(statistic.name()) {
+            channel.reading()
+        } else {
+            Err(())
+        }
+    }
 }
 
 #[derive(PartialEq, Copy, Clone)]
 pub enum Source {
-	/// Indicates that the source is a monotonically incrementing count.
-	Counter,
-	/// Indicates that the source is an instantaneous gauge reading.
-	Gauge,
-	/// Indicates that the source is an underlying distribution (histogram).
-	Distribution,
+    /// Indicates that the source is a monotonically incrementing count.
+    Counter,
+    /// Indicates that the source is an instantaneous gauge reading.
+    Gauge,
+    /// Indicates that the source is an underlying distribution (histogram).
+    Distribution,
 }
 
 pub trait Statistic<Value, Count>
 where
-	Value: crate::Value,
-	Count: crate::Count,
-	<Value as Atomic>::Primitive: Primitive,
-	<Count as Atomic>::Primitive: Primitive,
-	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
-	/// The name is used to lookup the channel for the statistic and should be
-	/// unique for each statistic.
-	fn name(&self) -> &str;
-	/// Indicates which source type the statistic tracks.
-	fn source(&self) -> Source;
-	/// Optionally, specify a summary type which is used to produce percentiles.
-	fn summary(&self) -> Option<Summary<Value, Count>> {
-		None
-	}
+    /// The name is used to lookup the channel for the statistic and should be
+    /// unique for each statistic.
+    fn name(&self) -> &str;
+    /// Indicates which source type the statistic tracks.
+    fn source(&self) -> Source;
+    /// Optionally, specify a summary type which is used to produce percentiles.
+    fn summary(&self) -> Option<Summary<Value, Count>> {
+        None
+    }
 }
 
 /// Internal type which stores fields necessary to track a corresponding
 /// statistic.
 struct Channel<Value, Count>
 where
-	Value: crate::Value,
-	Count: crate::Count,
-	<Value as Atomic>::Primitive: Primitive,
-	<Count as Atomic>::Primitive: Primitive,
-	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
-	refreshed: RwLock<Instant>,
-	empty: AtomicBool,
-	reading: Value,
-	summary: Option<SummaryType<Value, Count>>,
+    refreshed: RwLock<Instant>,
+    empty: AtomicBool,
+    reading: Value,
+    summary: Option<SummaryType<Value, Count>>,
 }
 
 impl<Value, Count> Channel<Value, Count>
 where
-	Value: crate::Value,
-	Count: crate::Count,
-	<Value as Atomic>::Primitive: Primitive,
-	<Count as Atomic>::Primitive: Primitive,
-	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
-	/// Creates an empty channel for a statistic.
-	fn new(statistic: &dyn Statistic<Value, Count>) -> Self {
-		let summary = statistic.summary().map(|v| v.inner);
-		Self {
-			empty: AtomicBool::new(true),
-			reading: Default::default(),
-			refreshed: RwLock::new(Instant::now()),
-			summary,
-		}
-	}
+    /// Creates an empty channel for a statistic.
+    fn new(statistic: &dyn Statistic<Value, Count>) -> Self {
+        let summary = statistic.summary().map(|v| v.inner);
+        Self {
+            empty: AtomicBool::new(true),
+            reading: Default::default(),
+            refreshed: RwLock::new(Instant::now()),
+            summary,
+        }
+    }
 
-	/// Records a bucket value + count pair into the summary.
-	fn record_bucket(&self, time: Instant, value: <Value as Atomic>::Primitive, count: <Count as Atomic>::Primitive) -> Result<(), ()> {
-		if let Some(summary) = &self.summary {
-			summary.increment(time, value, count);
-			Ok(())
-		} else {
-			Err(())
-		}
-	}
+    /// Records a bucket value + count pair into the summary.
+    fn record_bucket(
+        &self,
+        time: Instant,
+        value: <Value as Atomic>::Primitive,
+        count: <Count as Atomic>::Primitive,
+    ) -> Result<(), ()> {
+        if let Some(summary) = &self.summary {
+            summary.increment(time, value, count);
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
 
-	fn record_counter(&self, time: Instant, value: <Value as Atomic>::Primitive) {
-		if !self.empty.load(Ordering::Relaxed) {
-			if let Some(summary) = &self.summary {
-				let t0 = self.refreshed.write().unwrap();
-				let v0 = self.reading.load(Ordering::Relaxed);
-				let dt = time - *t0;
-				let dv = (value - v0).to_float();
-				let rate = (dv / (dt.as_secs() as f64 + dt.subsec_nanos() as f64 / 1_000_000_000.0)).ceil();
-				summary.increment(time, <Value as Atomic>::Primitive::from_float(rate), 1_u8.into());
-			}
-			self.reading.store(value, Ordering::Relaxed);
-		} else {
-			self.reading.store(value, Ordering::Relaxed);
-			self.empty.store(false, Ordering::Relaxed);
-		}
-	}
+    fn record_counter(&self, time: Instant, value: <Value as Atomic>::Primitive) {
+        if !self.empty.load(Ordering::Relaxed) {
+            if let Some(summary) = &self.summary {
+                let t0 = self.refreshed.write().unwrap();
+                let v0 = self.reading.load(Ordering::Relaxed);
+                let dt = time - *t0;
+                let dv = (value - v0).to_float();
+                let rate = (dv
+                    / (dt.as_secs() as f64 + dt.subsec_nanos() as f64 / 1_000_000_000.0))
+                    .ceil();
+                summary.increment(
+                    time,
+                    <Value as Atomic>::Primitive::from_float(rate),
+                    1_u8.into(),
+                );
+            }
+            self.reading.store(value, Ordering::Relaxed);
+        } else {
+            self.reading.store(value, Ordering::Relaxed);
+            self.empty.store(false, Ordering::Relaxed);
+        }
+    }
 
-	fn record_gauge(&self, time: Instant, value: <Value as Atomic>::Primitive) {
-		if let Some(summary) = &self.summary {
-			summary.increment(time, value, 1_u8.into());
-		}
-		self.reading.store(value, Ordering::Relaxed);
-		if self.empty.load(Ordering::Relaxed) {
-			self.empty.store(false, Ordering::Relaxed);
-		}
-	}
+    fn record_gauge(&self, time: Instant, value: <Value as Atomic>::Primitive) {
+        if let Some(summary) = &self.summary {
+            summary.increment(time, value, 1_u8.into());
+        }
+        self.reading.store(value, Ordering::Relaxed);
+        if self.empty.load(Ordering::Relaxed) {
+            self.empty.store(false, Ordering::Relaxed);
+        }
+    }
 
-	fn percentile(&self, percentile: f64) -> Result<<Value as Atomic>::Primitive, ()> {
-		if let Some(summary) = &self.summary {
-			summary.percentile(percentile).map_err(|_| ())
-		} else {
-			Err(())
-		}
-	}
+    fn percentile(&self, percentile: f64) -> Result<<Value as Atomic>::Primitive, ()> {
+        if let Some(summary) = &self.summary {
+            summary.percentile(percentile).map_err(|_| ())
+        } else {
+            Err(())
+        }
+    }
 
-	fn reading(&self) -> Result<<Value as Atomic>::Primitive, ()> {
-		if !self.empty.load(Ordering::Relaxed) {
-			Ok(self.reading.load(Ordering::Relaxed))
-		} else {
-			Err(())
-		}
-	}
+    fn reading(&self) -> Result<<Value as Atomic>::Primitive, ()> {
+        if !self.empty.load(Ordering::Relaxed) {
+            Ok(self.reading.load(Ordering::Relaxed))
+        } else {
+            Err(())
+        }
+    }
 }
 
 pub trait FloatConvert {
-	fn to_float(self) -> f64;
-	fn from_float(value: f64) -> Self;
+    fn to_float(self) -> f64;
+    fn from_float(value: f64) -> Self;
 }
 
 impl FloatConvert for u64 {
-	fn to_float(self) -> f64 {
-		self as f64
-	}
-	fn from_float(value: f64) -> Self {
-		value as Self
-	}
+    fn to_float(self) -> f64 {
+        self as f64
+    }
+    fn from_float(value: f64) -> Self {
+        value as Self
+    }
 }
 
 impl FloatConvert for u32 {
-	fn to_float(self) -> f64 {
-		self as f64
-	}
-	fn from_float(value: f64) -> Self {
-		value as Self
-	}
+    fn to_float(self) -> f64 {
+        self as f64
+    }
+    fn from_float(value: f64) -> Self {
+        value as Self
+    }
 }
 
 impl FloatConvert for u16 {
-	fn to_float(self) -> f64 {
-		self as f64
-	}
-	fn from_float(value: f64) -> Self {
-		value as Self
-	}
+    fn to_float(self) -> f64 {
+        self as f64
+    }
+    fn from_float(value: f64) -> Self {
+        value as Self
+    }
 }
 
 impl FloatConvert for u8 {
-	fn to_float(self) -> f64 {
-		self as f64
-	}
-	fn from_float(value: f64) -> Self {
-		value as Self
-	}
+    fn to_float(self) -> f64 {
+        self as f64
+    }
+    fn from_float(value: f64) -> Self {
+        value as Self
+    }
 }
 
 /// Specifies what type of structure should be used for producing summary
@@ -312,117 +349,134 @@ impl FloatConvert for u8 {
 /// 3250 times per second for a heatmap to make sense.  
 pub struct Summary<Value, Count>
 where
-	Value: crate::Value,
-	Count: crate::Count,
-	<Value as Atomic>::Primitive: Primitive,
-	<Count as Atomic>::Primitive: Primitive,
-	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
-	inner: SummaryType<Value, Count>,
+    inner: SummaryType<Value, Count>,
 }
 
 impl<Value, Count> Summary<Value, Count>
 where
-	Value: crate::Value,
-	Count: crate::Count,
-	<Value as Atomic>::Primitive: Primitive,
-	<Count as Atomic>::Primitive: Primitive,
-	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
-	/// Specify a heatmap summary will be used. Ideal for data sourced from
-	/// histograms.
-	pub fn heatmap(max: <Value as Atomic>::Primitive, precision: u8, windows: usize, resolution: Duration) -> Summary<Value, Count> {
-		Summary {
-			inner: SummaryType::Heatmap(AtomicHeatmap::<<Value as Atomic>::Primitive, Count>::new(max, precision, windows, resolution))
-		}
-	}
+    /// Specify a heatmap summary will be used. Ideal for data sourced from
+    /// histograms.
+    pub fn heatmap(
+        max: <Value as Atomic>::Primitive,
+        precision: u8,
+        windows: usize,
+        resolution: Duration,
+    ) -> Summary<Value, Count> {
+        Summary {
+            inner: SummaryType::Heatmap(AtomicHeatmap::<<Value as Atomic>::Primitive, Count>::new(
+                max, precision, windows, resolution,
+            )),
+        }
+    }
 
-	/// Specify that a stream summary will be used. Stores exactly capacity
-	/// previous values. 
-	pub fn stream(capacity: usize) -> Summary<Value, Count> {
-		Summary {
-			inner: SummaryType::Stream(AtomicStreamstats::<Value>::new(capacity))
-		}
-	}
+    /// Specify that a stream summary will be used. Stores exactly capacity
+    /// previous values.
+    pub fn stream(capacity: usize) -> Summary<Value, Count> {
+        Summary {
+            inner: SummaryType::Stream(AtomicStreamstats::<Value>::new(capacity)),
+        }
+    }
 }
 
 enum SummaryType<Value, Count>
 where
-	Value: crate::Value,
-	Count: crate::Count,
-	<Value as Atomic>::Primitive: Primitive,
-	<Count as Atomic>::Primitive: Primitive,
-	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
-	Heatmap(AtomicHeatmap<<Value as Atomic>::Primitive, Count>),
-	Stream(AtomicStreamstats<Value>),
+    Heatmap(AtomicHeatmap<<Value as Atomic>::Primitive, Count>),
+    Stream(AtomicStreamstats<Value>),
 }
 
 impl<Value, Count> SummaryType<Value, Count>
 where
-	Value: crate::Value,
-	Count: crate::Count,
-	<Value as Atomic>::Primitive: Primitive,
-	<Count as Atomic>::Primitive: Primitive,
-	u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
-	fn increment(&self, time: Instant, value: <Value as Atomic>::Primitive, count: <Count as Atomic>::Primitive) {
-		match self {
-			Self::Heatmap(heatmap) => heatmap.increment(time, value, count),
-			Self::Stream(stream) => stream.insert(value),
-		}
-	}
+    fn increment(
+        &self,
+        time: Instant,
+        value: <Value as Atomic>::Primitive,
+        count: <Count as Atomic>::Primitive,
+    ) {
+        match self {
+            Self::Heatmap(heatmap) => heatmap.increment(time, value, count),
+            Self::Stream(stream) => stream.insert(value),
+        }
+    }
 
-	fn percentile(&self, percentile: f64) -> Result<<Value as Atomic>::Primitive, ()> {
-		match self {
-			Self::Heatmap(heatmap) => heatmap.percentile(percentile).map_err(|_| ()),
-			Self::Stream(stream) => stream.percentile(percentile).map_err(|_| ()),
-		}
-	}
+    fn percentile(&self, percentile: f64) -> Result<<Value as Atomic>::Primitive, ()> {
+        match self {
+            Self::Heatmap(heatmap) => heatmap.percentile(percentile).map_err(|_| ()),
+            Self::Stream(stream) => stream.percentile(percentile).map_err(|_| ()),
+        }
+    }
 }
-
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	enum TestStat {
-		Alpha
-	}
+    enum TestStat {
+        Alpha,
+    }
 
-	impl Statistic<AtomicU64, AtomicU64> for TestStat {
-		fn name(&self) -> &str {
-			match self {
-				Self::Alpha => "alpha",
-			}
-		}
+    impl Statistic<AtomicU64, AtomicU64> for TestStat {
+        fn name(&self) -> &str {
+            match self {
+                Self::Alpha => "alpha",
+            }
+        }
 
-		fn source(&self) -> Source {
-			match self {
-				Self::Alpha => Source::Counter,
-			}
-		}
+        fn source(&self) -> Source {
+            match self {
+                Self::Alpha => Source::Counter,
+            }
+        }
 
-		fn summary(&self) -> Option<Summary<AtomicU64, AtomicU64>> {
-			match self {
-				Self::Alpha => Some(Summary::stream(1000)),
-			}
-		}
-	}
+        fn summary(&self) -> Option<Summary<AtomicU64, AtomicU64>> {
+            match self {
+                Self::Alpha => Some(Summary::stream(1000)),
+            }
+        }
+    }
 
     #[test]
     fn basic() {
-    	let metrics = Metrics::<AtomicU64, AtomicU64>::new();
-    	metrics.register(&TestStat::Alpha);
-    	assert!(metrics.reading(&TestStat::Alpha).is_err());
-    	metrics.record_counter(&TestStat::Alpha, Instant::now(), 0).expect("failed to record counter");
-    	assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
-    	let now = Instant::now();
-    	metrics.record_counter(&TestStat::Alpha, now, 0).expect("failed to record counter");
-    	assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
-    	assert_eq!(metrics.percentile(&TestStat::Alpha, 0.0), Ok(0));
-    	metrics.record_counter(&TestStat::Alpha, now + Duration::from_millis(1000), 1).expect("failed to record counter");
-    	assert_eq!(metrics.reading(&TestStat::Alpha), Ok(1));
-    	assert_eq!(metrics.percentile(&TestStat::Alpha, 100.0), Ok(1));
+        let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+        metrics.register(&TestStat::Alpha);
+        assert!(metrics.reading(&TestStat::Alpha).is_err());
+        metrics
+            .record_counter(&TestStat::Alpha, Instant::now(), 0)
+            .expect("failed to record counter");
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
+        let now = Instant::now();
+        metrics
+            .record_counter(&TestStat::Alpha, now, 0)
+            .expect("failed to record counter");
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
+        assert_eq!(metrics.percentile(&TestStat::Alpha, 0.0), Ok(0));
+        metrics
+            .record_counter(&TestStat::Alpha, now + Duration::from_millis(1000), 1)
+            .expect("failed to record counter");
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(1));
+        assert_eq!(metrics.percentile(&TestStat::Alpha, 100.0), Ok(1));
     }
 }

--- a/streamstats/Cargo.toml
+++ b/streamstats/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "streamstats"
+name = "rustcommon-streamstats"
 version = "0.1.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
@@ -7,4 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rustcommon-atomics = { path = "../atomics" }
 thiserror = "1.0.20"

--- a/streamstats/src/lib.rs
+++ b/streamstats/src/lib.rs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use std::sync::RwLock;
 use rustcommon_atomics::*;
+use std::sync::RwLock;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -56,7 +56,9 @@ where
             } else {
                 0
             };
-            let previous = self.current.compare_and_swap(current, next, Ordering::Relaxed);
+            let previous = self
+                .current
+                .compare_and_swap(current, next, Ordering::Relaxed);
             if previous == current {
                 break;
             } else {
@@ -82,13 +84,14 @@ where
     /// Return the value closest to the specified percentile. Returns an error
     /// if the value is outside of the histogram range or if the histogram is
     /// empty. Percentile must be within the range 0.0 to 100.0
-    pub fn percentile(&self, percentile: f64) -> Result<<T as Atomic>::Primitive, StreamstatsError> {
+    pub fn percentile(
+        &self,
+        percentile: f64,
+    ) -> Result<<T as Atomic>::Primitive, StreamstatsError> {
         if percentile < 0.0 || percentile > 100.0 {
             return Err(StreamstatsError::InvalidPercentile);
         }
-        let sorted_len = {
-            self.sorted.read().unwrap().len()
-        };
+        let sorted_len = { self.sorted.read().unwrap().len() };
         if sorted_len == 0 {
             let values = self.values();
             if values == 0 {

--- a/streamstats/src/lib.rs
+++ b/streamstats/src/lib.rs
@@ -2,14 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-pub trait Value: Default + Copy + Ord {}
-
-impl Value for u64 {}
-impl Value for u32 {}
-impl Value for u16 {}
-impl Value for u8 {}
-impl Value for usize {}
-
+use std::sync::RwLock;
+use rustcommon_atomics::*;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -21,6 +15,113 @@ pub enum StreamstatsError {
     InvalidPercentile,
 }
 
+pub struct AtomicStreamstats<T>
+where
+    T: Atomic,
+    <T as Atomic>::Primitive: Ord,
+{
+    buffer: Vec<T>,
+    current: AtomicUsize,
+    len: AtomicUsize,
+    sorted: RwLock<Vec<<T as Atomic>::Primitive>>,
+}
+
+impl<T> AtomicStreamstats<T>
+where
+    T: Atomic + Default,
+    <T as Atomic>::Primitive: Copy + Ord,
+{
+    /// Create a new struct which can hold up to `capacity` values in the
+    /// buffer.
+    pub fn new(capacity: usize) -> Self {
+        let mut buffer = Vec::with_capacity(capacity);
+        let sorted = RwLock::new(Vec::<<T as Atomic>::Primitive>::with_capacity(capacity));
+        for _ in 0..capacity {
+            buffer.push(Default::default());
+        }
+        Self {
+            buffer,
+            current: AtomicUsize::new(0),
+            len: AtomicUsize::new(0),
+            sorted,
+        }
+    }
+
+    /// Insert a new value into the buffer.
+    pub fn insert(&self, value: <T as Atomic>::Primitive) {
+        let mut current = self.current.load(Ordering::Relaxed);
+        loop {
+            let next = if current < (self.buffer.len() - 1) {
+                current + 1
+            } else {
+                0
+            };
+            let previous = self.current.compare_and_swap(current, next, Ordering::Relaxed);
+            if previous == current {
+                break;
+            } else {
+                current = previous;
+            }
+        }
+        self.buffer[current].store(value, Ordering::Relaxed);
+        if self.len.load(Ordering::Relaxed) < self.buffer.len() {
+            self.len.fetch_add(1, Ordering::Relaxed);
+        }
+        self.sorted.write().unwrap().clear(); // resort required
+    }
+
+    fn values(&self) -> usize {
+        let len = self.len.load(Ordering::Relaxed);
+        if len < self.buffer.len() {
+            len
+        } else {
+            self.buffer.len()
+        }
+    }
+
+    /// Return the value closest to the specified percentile. Returns an error
+    /// if the value is outside of the histogram range or if the histogram is
+    /// empty. Percentile must be within the range 0.0 to 100.0
+    pub fn percentile(&self, percentile: f64) -> Result<<T as Atomic>::Primitive, StreamstatsError> {
+        if percentile < 0.0 || percentile > 100.0 {
+            return Err(StreamstatsError::InvalidPercentile);
+        }
+        let sorted_len = {
+            self.sorted.read().unwrap().len()
+        };
+        if sorted_len == 0 {
+            let values = self.values();
+            if values == 0 {
+                return Err(StreamstatsError::Empty);
+            } else {
+                let mut sorted = self.sorted.write().unwrap();
+                let values = self.values();
+                for i in 0..values {
+                    sorted.push(self.buffer[i].load(Ordering::Relaxed));
+                }
+                sorted.sort();
+            }
+        }
+        let sorted = self.sorted.read().unwrap();
+        if sorted.len() > 0 {
+            if percentile == 0.0 {
+                Ok(sorted[0])
+            } else {
+                let need = (percentile / 100.0 * sorted.len() as f64).ceil() as usize;
+                Ok(sorted[need - 1])
+            }
+        } else {
+            Err(StreamstatsError::Empty)
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.current.store(0, Ordering::Relaxed);
+        self.len.store(0, Ordering::Relaxed);
+        self.sorted.write().unwrap().clear();
+    }
+}
+
 pub struct Streamstats<T> {
     buffer: Vec<T>,
     current: usize,
@@ -30,7 +131,7 @@ pub struct Streamstats<T> {
 
 impl<T> Streamstats<T>
 where
-    T: Value,
+    T: Default + Copy + Ord,
 {
     /// Create a new struct which can hold up to `capacity` values in the
     /// buffer.
@@ -122,6 +223,18 @@ mod tests {
     #[test]
     fn basic() {
         let mut streamstats = Streamstats::<u64>::new(1000);
+        assert_eq!(streamstats.percentile(0.0), Err(StreamstatsError::Empty));
+        streamstats.insert(1);
+        assert_eq!(streamstats.percentile(0.0), Ok(1));
+        streamstats.clear();
+        assert_eq!(streamstats.percentile(0.0), Err(StreamstatsError::Empty));
+
+        for i in 0..=10_000 {
+            streamstats.insert(i);
+            assert_eq!(streamstats.percentile(100.0), Ok(i));
+        }
+
+        let mut streamstats = AtomicStreamstats::<AtomicU64>::new(1000);
         assert_eq!(streamstats.percentile(0.0), Err(StreamstatsError::Empty));
         streamstats.insert(1);
         assert_eq!(streamstats.percentile(0.0), Ok(1));


### PR DESCRIPTION
Adds a work-in-progress metrics library which will eventually be
used to replace the existing metrics library. Makes better use of
generic types to allow specifying the precision of both recorded
values and internal counters. Additionally, allows for using more
efficient datastructures for summarization.
