### PR TITLE
metrics: add method to add summary to registered statistic

### DIFF
--- a/metrics/src/channel/mod.rs
+++ b/metrics/src/channel/mod.rs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::Summary;
 use crate::summary::SummaryStruct;
 use crate::traits::*;
+use crate::Summary;
 
 use rustcommon_atomics::{Atomic, AtomicBool, Ordering};
 

--- a/metrics/src/channel/mod.rs
+++ b/metrics/src/channel/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use crate::Summary;
 use crate::summary::SummaryStruct;
 use crate::traits::*;
 
@@ -111,5 +112,11 @@ where
         } else {
             Err(())
         }
+    }
+
+    /// Set a summary to be used for an existing channel
+    pub fn set_summary(&mut self, summary: Summary<Value, Count>) {
+        let summary = summary.build();
+        self.summary = Some(summary);
     }
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -69,4 +69,14 @@ mod tests {
         assert_eq!(metrics.reading(&TestStat::Alpha), Ok(1));
         assert_eq!(metrics.percentile(&TestStat::Alpha, 100.0), Ok(1));
     }
+
+    #[test]
+    fn outputs() {
+        let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+        metrics.register(&TestStat::Alpha);
+        assert!(metrics.snapshot().is_empty());
+        metrics.add_output(&TestStat::Alpha, Output::Reading);
+        let _ = metrics.record_counter(&TestStat::Alpha, Instant::now(), 1);
+        assert_eq!(metrics.snapshot().len(), 1);
+    }
 }

--- a/metrics/src/metrics/mod.rs
+++ b/metrics/src/metrics/mod.rs
@@ -85,7 +85,11 @@ where
     /// when the parameters are not known at compile time. For example, if a
     /// sampling rate is user configurable at runtime, the number of samples
     /// may need to be higher for stream summaries.
-    pub fn set_summary(&self, statistic: &dyn Statistic<Value, Count>, summary: Summary<Value, Count>) {
+    pub fn set_summary(
+        &self,
+        statistic: &dyn Statistic<Value, Count>,
+        summary: Summary<Value, Count>,
+    ) {
         let entry = Entry::from(statistic);
         if let Some(mut channel) = self.channels.get_mut(&entry) {
             channel.set_summary(summary);

--- a/metrics/src/metrics/mod.rs
+++ b/metrics/src/metrics/mod.rs
@@ -68,7 +68,7 @@ where
     /// Adds a new output to the registry which will be included in future
     /// snapshots. If the statistic is not already tracked, it will be
     /// registered.
-    pub fn register_output(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
+    pub fn add_output(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
         self.register(statistic);
         self.outputs.register(statistic, output);
     }
@@ -77,8 +77,19 @@ where
     /// future snapshots. This will not remove the related datastructures for
     /// the statistic even if no outputs remain. Use `deregister` method to stop
     /// tracking a statistic entirely.
-    pub fn deregister_output(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
+    pub fn remove_output(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
         self.outputs.deregister(statistic, output);
+    }
+
+    /// Add a `Summary` for an already registered `Statistic`. This can be used
+    /// when the parameters are not known at compile time. For example, if a
+    /// sampling rate is user configurable at runtime, the number of samples
+    /// may need to be higher for stream summaries.
+    pub fn set_summary(&self, statistic: &dyn Statistic<Value, Count>, summary: Summary<Value, Count>) {
+        let entry = Entry::from(statistic);
+        if let Some(mut channel) = self.channels.get_mut(&entry) {
+            channel.set_summary(summary);
+        }
     }
 
     /// Remove all statistics and outputs.


### PR DESCRIPTION
Problem

For some use-cases, we might not know the parameters for a summary
until runtime. For example, an application with a dynamic sampling rate
that still needs to use a streaming summary for percentiles might not
know the number of samples to retain for percentile calculation until
runtime. This can make statistic types harder to implement in order to
allow dynamic summary configurations.

Solution

Add a method to set the summary type for an already registered statistic

Result

Easier to implement dynamic configuration of summary types
