### PR TITLE
metrics: add function to add a summary if one doesn't exist

### DIFF
--- a/metrics/src/channel/mod.rs
+++ b/metrics/src/channel/mod.rs
@@ -122,4 +122,11 @@ where
         let summary = summary.build();
         self.summary = Some(summary);
     }
+
+    /// Set a summary to be used for an existing channel
+    pub fn add_summary(&mut self, summary: Summary<Value, Count>) {
+        if self.summary.is_none() {
+            self.set_summary(summary);
+        }
+    }
 }

--- a/metrics/src/metrics/mod.rs
+++ b/metrics/src/metrics/mod.rs
@@ -81,9 +81,9 @@ where
         self.outputs.deregister(statistic, output);
     }
 
-    /// Add a `Summary` for an already registered `Statistic`. This can be used
-    /// when the parameters are not known at compile time. For example, if a
-    /// sampling rate is user configurable at runtime, the number of samples
+    /// Set the `Summary` for an already registered `Statistic`. This can be
+    /// used when the parameters are not known at compile time. For example, if
+    /// a sampling rate is user configurable at runtime, the number of samples
     /// may need to be higher for stream summaries.
     pub fn set_summary(
         &self,
@@ -93,6 +93,20 @@ where
         let entry = Entry::from(statistic);
         if let Some(mut channel) = self.channels.get_mut(&entry) {
             channel.set_summary(summary);
+        }
+    }
+
+    /// Conditionally add a `Summary` for a `Statistic` if one is not currently
+    /// set. This may be used for dynamically registered statistic types to
+    /// prevent clearing an existing summary.
+    pub fn add_summary(
+        &self,
+        statistic: &dyn Statistic<Value, Count>,
+        summary: Summary<Value, Count>,
+    ) {
+        let entry = Entry::from(statistic);
+        if let Some(mut channel) = self.channels.get_mut(&entry) {
+            channel.add_summary(summary);
         }
     }
 


### PR DESCRIPTION
Currently, we have `set_summary` function, which will update the
summary structure for the channel unconditionally. For some
use-cases, we might want to conditionally add a summary struct to
the existing channel. This may be used for dynamically registered
metric sources.
