### PR TITLE
waterfall: refactor to use standalone heatmap crate

### DIFF
--- a/heatmap/src/atomic.rs
+++ b/heatmap/src/atomic.rs
@@ -1,0 +1,116 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::Heatmap;
+pub use rustcommon_atomics::*;
+use rustcommon_histogram::AtomicHistogram;
+pub use rustcommon_histogram::{AtomicCounter, Counter, HistogramError, Indexing};
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+
+pub struct AtomicHeatmap<Value, Count> {
+    slices: Vec<AtomicHistogram<Value, Count>>,
+    current: AtomicUsize,
+    next_tick: RwLock<Instant>,
+    resolution: Duration,
+    summary: AtomicHistogram<Value, Count>,
+}
+
+impl<Value, Count> AtomicHeatmap<Value, Count>
+where
+    Value: Indexing,
+    Count: AtomicCounter + Default,
+    u64: From<Value> + From<<Count as Atomic>::Primitive>,
+    <Count as Atomic>::Primitive: Copy,
+{
+    pub fn new(max: Value, precision: u8, windows: usize, resolution: Duration) -> Self {
+        let mut slices = Vec::new();
+        for _ in 0..windows {
+            slices.push(AtomicHistogram::new(max, precision));
+        }
+        slices.shrink_to_fit();
+        Self {
+            slices,
+            current: AtomicUsize::new(0),
+            next_tick: RwLock::new(Instant::now() + resolution),
+            resolution,
+            summary: AtomicHistogram::new(max, precision),
+        }
+    }
+
+    pub fn increment(&self, time: Instant, value: Value, count: <Count as Atomic>::Primitive) {
+        self.tick(time);
+        self.slices[self.current.load(Ordering::Relaxed)].increment(value, count);
+        self.summary.increment(value, count);
+    }
+
+    pub fn percentile(&self, percentile: f64) -> Result<Value, HistogramError> {
+        self.tick(Instant::now());
+        self.summary.percentile(percentile)
+    }
+
+    fn tick(&self, time: Instant) {
+        loop {
+            if time < *self.next_tick.read().unwrap() {
+                return;
+            } else {
+                let mut next_tick = self.next_tick.write().unwrap();
+                *next_tick += self.resolution;
+                self.current.fetch_add(1, Ordering::Relaxed);
+                if self.current.load(Ordering::Relaxed) >= self.slices.len() {
+                    self.current.store(0, Ordering::Relaxed);
+                }
+                let current = self.current.load(Ordering::Relaxed);
+                self.summary.sub_assign(&self.slices[current]);
+                self.slices[current].clear();
+            }
+        }
+    }
+
+    pub fn load(&self) -> Heatmap<Value, <Count as Atomic>::Primitive>
+    where
+        Value: Copy + std::ops::Sub<Output = Value>,
+        <Count as Atomic>::Primitive: Counter,
+    {
+        let mut result = Heatmap {
+            slices: Vec::with_capacity(self.slices.len()),
+            current: self.current.load(Ordering::Relaxed),
+            next_tick: self.next_tick.read().unwrap().clone(),
+            resolution: self.resolution,
+            summary: self.summary.load(),
+        };
+        for slice in &self.slices {
+            result.slices.push(slice.load());
+        }
+        result.slices.shrink_to_fit();
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn age_out() {
+        let mut heatmap = Heatmap::<u64, u64>::new(1_000_000, 2, 1000, Duration::from_millis(1));
+        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+        heatmap.increment(Instant::now(), 1, 1);
+        assert_eq!(heatmap.percentile(0.0), Ok(1));
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(heatmap.percentile(0.0), Ok(1));
+        std::thread::sleep(Duration::from_millis(2000));
+        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+
+        let heatmap =
+            AtomicHeatmap::<u64, AtomicU64>::new(1_000_000, 2, 1000, Duration::from_millis(1));
+        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+        heatmap.increment(Instant::now(), 1, 1);
+        assert_eq!(heatmap.percentile(0.0), Ok(1));
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(heatmap.percentile(0.0), Ok(1));
+        std::thread::sleep(Duration::from_millis(2000));
+        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+    }
+}

--- a/heatmap/src/lib.rs
+++ b/heatmap/src/lib.rs
@@ -7,11 +7,11 @@ mod slice;
 mod standard;
 
 pub use atomic::AtomicHeatmap;
-pub use standard::Heatmap;
 pub use slice::Slice;
+pub use standard::Heatmap;
 
 pub use rustcommon_atomics::{Atomic, AtomicU16, AtomicU32, AtomicU64, AtomicU8};
-pub use rustcommon_histogram::{AtomicCounter, Counter, Indexing, HistogramError};
+pub use rustcommon_histogram::{AtomicCounter, Counter, HistogramError, Indexing};
 
 #[cfg(test)]
 mod tests {

--- a/heatmap/src/lib.rs
+++ b/heatmap/src/lib.rs
@@ -2,126 +2,22 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-pub use rustcommon_atomics::*;
-pub use rustcommon_histogram::{AtomicCounter, Counter, HistogramError, Indexing};
-use rustcommon_histogram::{AtomicHistogram, Histogram};
-use std::sync::RwLock;
-use std::time::{Duration, Instant};
+mod atomic;
+mod slice;
+mod standard;
 
-pub struct Heatmap<Value, Count> {
-    slices: Vec<Histogram<Value, Count>>,
-    current: usize,
-    next_tick: Instant,
-    resolution: Duration,
-    summary: Histogram<Value, Count>,
-}
+pub use atomic::AtomicHeatmap;
+pub use standard::Heatmap;
+pub use slice::Slice;
 
-impl<Value, Count> Heatmap<Value, Count>
-where
-    Value: Indexing,
-    Count: Counter,
-    u64: From<Value> + From<Count>,
-{
-    pub fn new(max: Value, precision: u8, windows: usize, resolution: Duration) -> Self {
-        let mut slices = Vec::new();
-        for _ in 0..windows {
-            slices.push(Histogram::new(max, precision));
-        }
-        Self {
-            slices,
-            current: 0,
-            next_tick: Instant::now() + resolution,
-            resolution,
-            summary: Histogram::new(max, precision),
-        }
-    }
-
-    pub fn increment(&mut self, time: Instant, value: Value, count: Count) {
-        self.tick(time);
-        self.slices[self.current].increment(value, count);
-        self.summary.increment(value, count);
-    }
-
-    pub fn percentile(&mut self, percentile: f64) -> Result<Value, HistogramError> {
-        self.tick(Instant::now());
-        self.summary.percentile(percentile)
-    }
-
-    fn tick(&mut self, time: Instant) {
-        while time >= self.next_tick {
-            self.current += 1;
-            if self.current >= self.slices.len() {
-                self.current = 0;
-            }
-            self.next_tick += self.resolution;
-            self.summary.sub_assign(&self.slices[self.current]);
-            self.slices[self.current].clear();
-        }
-    }
-}
-
-pub struct AtomicHeatmap<Value, Count> {
-    slices: Vec<AtomicHistogram<Value, Count>>,
-    current: AtomicUsize,
-    next_tick: RwLock<Instant>,
-    resolution: Duration,
-    summary: AtomicHistogram<Value, Count>,
-}
-
-impl<Value, Count> AtomicHeatmap<Value, Count>
-where
-    Value: Indexing,
-    Count: AtomicCounter + Default,
-    u64: From<Value> + From<<Count as Atomic>::Primitive>,
-    <Count as Atomic>::Primitive: Copy,
-{
-    pub fn new(max: Value, precision: u8, windows: usize, resolution: Duration) -> Self {
-        let mut slices = Vec::new();
-        for _ in 0..windows {
-            slices.push(AtomicHistogram::new(max, precision));
-        }
-        Self {
-            slices,
-            current: AtomicUsize::new(0),
-            next_tick: RwLock::new(Instant::now() + resolution),
-            resolution,
-            summary: AtomicHistogram::new(max, precision),
-        }
-    }
-
-    pub fn increment(&self, time: Instant, value: Value, count: <Count as Atomic>::Primitive) {
-        self.tick(time);
-        self.slices[self.current.load(Ordering::Relaxed)].increment(value, count);
-        self.summary.increment(value, count);
-    }
-
-    pub fn percentile(&self, percentile: f64) -> Result<Value, HistogramError> {
-        self.tick(Instant::now());
-        self.summary.percentile(percentile)
-    }
-
-    fn tick(&self, time: Instant) {
-        loop {
-            if time < *self.next_tick.read().unwrap() {
-                return;
-            } else {
-                let mut next_tick = self.next_tick.write().unwrap();
-                *next_tick += self.resolution;
-                self.current.fetch_add(1, Ordering::Relaxed);
-                if self.current.load(Ordering::Relaxed) >= self.slices.len() {
-                    self.current.store(0, Ordering::Relaxed);
-                }
-                let current = self.current.load(Ordering::Relaxed);
-                self.summary.sub_assign(&self.slices[current]);
-                self.slices[current].clear();
-            }
-        }
-    }
-}
+pub use rustcommon_atomics::{Atomic, AtomicU16, AtomicU32, AtomicU64, AtomicU8};
+pub use rustcommon_histogram::{AtomicCounter, Counter, Indexing, HistogramError};
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::time::Duration;
+    use std::time::Instant;
 
     #[test]
     fn age_out() {

--- a/heatmap/src/slice.rs
+++ b/heatmap/src/slice.rs
@@ -2,21 +2,21 @@ use rustcommon_histogram::Histogram;
 use std::time::Instant;
 
 pub struct Slice<Value, Count> {
-	pub(crate) start: Instant,
-	pub(crate) stop: Instant,
-	pub(crate) histogram: Histogram<Value, Count>,
+    pub(crate) start: Instant,
+    pub(crate) stop: Instant,
+    pub(crate) histogram: Histogram<Value, Count>,
 }
 
 impl<Value, Count> Slice<Value, Count> {
-	pub fn start(&self) -> Instant {
-		self.start
-	}
+    pub fn start(&self) -> Instant {
+        self.start
+    }
 
-	pub fn stop(&self) -> Instant {
-		self.stop
-	}
+    pub fn stop(&self) -> Instant {
+        self.stop
+    }
 
-	pub fn histogram(&self) -> &Histogram<Value, Count> {
-		&self.histogram
-	}
+    pub fn histogram(&self) -> &Histogram<Value, Count> {
+        &self.histogram
+    }
 }

--- a/heatmap/src/slice.rs
+++ b/heatmap/src/slice.rs
@@ -1,0 +1,22 @@
+use rustcommon_histogram::Histogram;
+use std::time::Instant;
+
+pub struct Slice<Value, Count> {
+	pub(crate) start: Instant,
+	pub(crate) stop: Instant,
+	pub(crate) histogram: Histogram<Value, Count>,
+}
+
+impl<Value, Count> Slice<Value, Count> {
+	pub fn start(&self) -> Instant {
+		self.start
+	}
+
+	pub fn stop(&self) -> Instant {
+		self.stop
+	}
+
+	pub fn histogram(&self) -> &Histogram<Value, Count> {
+		&self.histogram
+	}
+}

--- a/heatmap/src/standard.rs
+++ b/heatmap/src/standard.rs
@@ -69,7 +69,8 @@ where
     fn get_slice(&self, index: usize) -> Option<Slice<Value, Count>> {
         if let Some(histogram) = self.slices.get(index).map(|v| (*v).clone()) {
             let shift = if index > self.current {
-                self.resolution.mul_f64((self.slices.len() + self.current - index) as f64)
+                self.resolution
+                    .mul_f64((self.slices.len() + self.current - index) as f64)
             } else {
                 self.resolution.mul_f64((self.current - index) as f64)
             };
@@ -107,7 +108,11 @@ where
         } else {
             0
         };
-        Iter { inner, index, visited: 0 }
+        Iter {
+            inner,
+            index,
+            visited: 0,
+        }
     }
 }
 
@@ -131,7 +136,6 @@ where
             self.visited += 1;
             bucket
         }
-        
     }
 }
 

--- a/heatmap/src/standard.rs
+++ b/heatmap/src/standard.rs
@@ -1,0 +1,150 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::slice::Slice;
+use rustcommon_histogram::{Counter, Histogram, HistogramError, Indexing};
+
+use std::time::{Duration, Instant};
+
+pub struct Heatmap<Value, Count> {
+    pub(crate) slices: Vec<Histogram<Value, Count>>,
+    pub(crate) current: usize,
+    pub(crate) next_tick: Instant,
+    pub(crate) resolution: Duration,
+    pub(crate) summary: Histogram<Value, Count>,
+}
+
+impl<Value, Count> Heatmap<Value, Count>
+where
+    Value: Indexing,
+    Count: Counter,
+    u64: From<Value> + From<Count>,
+{
+    pub fn new(max: Value, precision: u8, windows: usize, resolution: Duration) -> Self {
+        let mut slices = Vec::new();
+        for _ in 0..windows {
+            slices.push(Histogram::new(max, precision));
+        }
+        Self {
+            slices,
+            current: 0,
+            next_tick: Instant::now() + resolution,
+            resolution,
+            summary: Histogram::new(max, precision),
+        }
+    }
+
+    pub fn slices(&self) -> usize {
+        self.slices.len()
+    }
+
+    pub fn buckets(&self) -> usize {
+        self.summary.buckets()
+    }
+
+    pub fn increment(&mut self, time: Instant, value: Value, count: Count) {
+        self.tick(time);
+        self.slices[self.current].increment(value, count);
+        self.summary.increment(value, count);
+    }
+
+    pub fn percentile(&mut self, percentile: f64) -> Result<Value, HistogramError> {
+        self.tick(Instant::now());
+        self.summary.percentile(percentile)
+    }
+
+    fn tick(&mut self, time: Instant) {
+        while time >= self.next_tick {
+            self.current += 1;
+            if self.current >= self.slices.len() {
+                self.current = 0;
+            }
+            self.next_tick += self.resolution;
+            self.summary.sub_assign(&self.slices[self.current]);
+            self.slices[self.current].clear();
+        }
+    }
+
+    fn get_slice(&self, index: usize) -> Option<Slice<Value, Count>> {
+        if let Some(histogram) = self.slices.get(index).map(|v| (*v).clone()) {
+            let shift = if index > self.current {
+                self.resolution.mul_f64((self.slices.len() + self.current - index) as f64)
+            } else {
+                self.resolution.mul_f64((self.current - index) as f64)
+            };
+            Some(Slice {
+                start: self.next_tick - shift - self.resolution,
+                stop: self.next_tick - shift,
+                histogram,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+pub struct Iter<'a, Value, Count>
+where
+    Value: Indexing,
+    Count: Counter,
+    u64: From<Value> + From<Count>,
+{
+    inner: &'a Heatmap<Value, Count>,
+    index: usize,
+    visited: usize,
+}
+
+impl<'a, Value, Count> Iter<'a, Value, Count>
+where
+    Value: Indexing,
+    Count: Counter,
+    u64: From<Value> + From<Count>,
+{
+    fn new(inner: &'a Heatmap<Value, Count>) -> Iter<'a, Value, Count> {
+        let index = if inner.current < (inner.slices.len() - 1) {
+            inner.current + 1
+        } else {
+            0
+        };
+        Iter { inner, index, visited: 0 }
+    }
+}
+
+impl<'a, Value, Count> Iterator for Iter<'a, Value, Count>
+where
+    Value: Indexing,
+    Count: Counter,
+    u64: From<Value> + From<Count>,
+{
+    type Item = Slice<Value, Count>;
+
+    fn next(&mut self) -> Option<Slice<Value, Count>> {
+        if self.visited >= self.inner.slices.len() {
+            None
+        } else {
+            let bucket = self.inner.get_slice(self.index);
+            self.index += 1;
+            if self.index >= self.inner.slices.len() {
+                self.index = 0;
+            }
+            self.visited += 1;
+            bucket
+        }
+        
+    }
+}
+
+impl<'a, Value, Count> IntoIterator for &'a Heatmap<Value, Count>
+where
+    Value: Indexing,
+    Count: Counter,
+    u64: From<Value> + From<Count>,
+{
+    type Item = Slice<Value, Count>;
+    type IntoIter = Iter<'a, Value, Count>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Iter::new(self)
+    }
+}

--- a/histogram/src/histograms/standard.rs
+++ b/histogram/src/histograms/standard.rs
@@ -4,6 +4,7 @@
 
 use crate::{Bucket, Counter, HistogramError, Indexing};
 
+#[derive(Clone)]
 /// A histogram type which follows normal ownership rules.
 pub struct Histogram<Value, Count> {
     buckets: Vec<Count>,
@@ -39,6 +40,7 @@ where
         for _ in 0..=max_index {
             buckets.push(Count::default());
         }
+        buckets.shrink_to_fit();
         histogram.buckets = buckets;
 
         histogram
@@ -69,6 +71,10 @@ where
             self.buckets[i] = Count::default();
         }
         self.too_high = Count::default();
+    }
+
+    pub fn buckets(&self) -> usize {
+        self.buckets.len()
     }
 
     /// Return the value closest to the specified percentile. Returns an error

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -14,9 +14,11 @@ pub use error::*;
 pub use histograms::*;
 pub use indexing::*;
 
+pub use rustcommon_atomics::{Atomic, AtomicU8, AtomicU16, AtomicU32, AtomicU64};
+
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::*;
 
     #[test]
     fn build() {

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -14,7 +14,7 @@ pub use error::*;
 pub use histograms::*;
 pub use indexing::*;
 
-pub use rustcommon_atomics::{Atomic, AtomicU8, AtomicU16, AtomicU32, AtomicU64};
+pub use rustcommon_atomics::{Atomic, AtomicU16, AtomicU32, AtomicU64, AtomicU8};
 
 #[cfg(test)]
 mod tests {

--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -9,14 +9,14 @@ homepage = "https://github.com/twitter/rustcommon/waterfall"
 repository = "https://github.com/twitter/rustcommon"
 
 [dependencies]
+chrono = "0.4.15"
 dejavu = "2.37.0"
 hsl = "0.1.1"
 log = "0.4.8"
 png = "0.16.3"
-rustcommon-atomics = { path = "../atomics" }
-rustcommon-datastructures = { path = "../datastructures" }
+rustcommon-heatmap = { path = "../heatmap" }
+rustcommon-histogram = { path = "../histogram" }
 rusttype = "0.8.3"
-time = "0.1.42"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/waterfall/examples/simulator.rs
+++ b/waterfall/examples/simulator.rs
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_waterfall::WaterfallBuilder;
-use std::time::Instant;
-use std::time::Duration;
 use rand::thread_rng;
 use rand_distr::*;
 use rustcommon_logger::*;
+use rustcommon_waterfall::WaterfallBuilder;
+use std::time::Duration;
+use std::time::Instant;
 
 fn main() {
     Logger::new()
@@ -42,7 +42,8 @@ pub fn simulate(shape: Shape) {
     println!("simulating for {:?}", shape);
     let duration = 120;
 
-    let mut heatmap = rustcommon_heatmap::Heatmap::<u64, u64>::new(1_000_000, 3, 120, Duration::new(1,0));
+    let mut heatmap =
+        rustcommon_heatmap::Heatmap::<u64, u64>::new(1_000_000, 3, 120, Duration::new(1, 0));
 
     let cauchy = Cauchy::new(500_000.0, 2_000.00).unwrap();
     let normal = Normal::new(200_000.0, 100_000.0).unwrap();

--- a/waterfall/examples/simulator.rs
+++ b/waterfall/examples/simulator.rs
@@ -2,15 +2,12 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-#![allow(unused_imports)]
-use rand::{thread_rng, Rng};
+use rustcommon_waterfall::WaterfallBuilder;
+use std::time::Instant;
+use std::time::Duration;
+use rand::thread_rng;
 use rand_distr::*;
-use rustcommon_datastructures::*;
 use rustcommon_logger::*;
-
-use std::collections::HashMap;
-
-pub const SECOND: u64 = 1_000_000_000;
 
 fn main() {
     Logger::new()
@@ -45,27 +42,21 @@ pub fn simulate(shape: Shape) {
     println!("simulating for {:?}", shape);
     let duration = 120;
 
-    let heatmap = Heatmap::<AtomicU64>::new(SECOND, 3, SECOND, duration * SECOND);
+    let mut heatmap = rustcommon_heatmap::Heatmap::<u64, u64>::new(1_000_000, 3, 120, Duration::new(1,0));
 
     let cauchy = Cauchy::new(500_000.0, 2_000.00).unwrap();
     let normal = Normal::new(200_000.0, 100_000.0).unwrap();
     let uniform = Uniform::new_inclusive(10_000.0, 200_000.0);
-    let triangular = Triangular::new(1.0, 2_000_000.0, 50_000.0).unwrap();
+    let triangular = Triangular::new(1.0, 200_000.0, 50_000.0).unwrap();
     let gamma = Gamma::new(2.0, 2.0).unwrap();
 
     let start = std::time::Instant::now();
-    let mut latch = std::time::Instant::now();
-
     let mut rng = thread_rng();
 
     loop {
         let now = std::time::Instant::now();
         if now - start >= std::time::Duration::new(duration, 0) {
             break;
-        }
-        if now - latch >= std::time::Duration::new(1, 0) {
-            heatmap.latch();
-            latch = now;
         }
         let value: f64 = match shape {
             Shape::Cauchy => cauchy.sample(&mut rng),
@@ -75,43 +66,21 @@ pub fn simulate(shape: Shape) {
             Shape::Gamma => gamma.sample(&mut rng) * 1_000_000.0,
         };
         let value = value.floor() as u64;
-        heatmap.increment(time::precise_time_ns(), value, 1);
+        heatmap.increment(Instant::now(), value, 1);
     }
 
-    render(shape, heatmap);
-}
-
-pub fn render(shape: Shape, heatmap: Heatmap<AtomicU64>) {
-    let mut labels = HashMap::new();
-    labels.insert(100, "100ns".to_string());
-    labels.insert(200, "200ns".to_string());
-    labels.insert(400, "400ns".to_string());
-    labels.insert(1_000, "1us".to_string());
-    labels.insert(2_000, "2us".to_string());
-    labels.insert(4_000, "4us".to_string());
-    labels.insert(10_000, "10us".to_string());
-    labels.insert(20_000, "20us".to_string());
-    labels.insert(40_000, "40us".to_string());
-    labels.insert(100_000, "100us".to_string());
-    labels.insert(200_000, "200us".to_string());
-    labels.insert(400_000, "400us".to_string());
-    labels.insert(1_000_000, "1ms".to_string());
-    labels.insert(2_000_000, "2ms".to_string());
-    labels.insert(4_000_000, "4ms".to_string());
-    labels.insert(10_000_000, "10ms".to_string());
-    labels.insert(20_000_000, "20ms".to_string());
-    labels.insert(40_000_000, "40ms".to_string());
-    labels.insert(100_000_000, "100ms".to_string());
-    labels.insert(200_000_000, "200ms".to_string());
-    labels.insert(400_000_000, "400ms".to_string());
-
     let filename = match shape {
-        Shape::Cauchy => "cauchy.png",
-        Shape::Normal => "normal.png",
-        Shape::Uniform => "uniform.png",
-        Shape::Triangular => "triangular.png",
-        Shape::Gamma => "gamma.png",
+        Shape::Cauchy => "cauchy_new.png",
+        Shape::Normal => "normal_new.png",
+        Shape::Uniform => "uniform_new.png",
+        Shape::Triangular => "triangular_new.png",
+        Shape::Gamma => "gamma_new.png",
     };
 
-    rustcommon_waterfall::save_waterfall(&heatmap, filename, labels, 60 * SECOND);
+    WaterfallBuilder::new(filename)
+        .label(100, "100")
+        .label(1000, "1000")
+        .label(10000, "10000")
+        .label(100000, "100000")
+        .build(&heatmap);
 }

--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -4,18 +4,18 @@
 
 //! This crate is used to render a waterfall style plot of a heatmap
 
-use rustcommon_heatmap::*;
-use core::ops::Sub;
-use std::convert::From;
 use chrono::Utc;
 use core::hash::Hash;
+use core::ops::Sub;
 use hsl::HSL;
+use rustcommon_heatmap::*;
 use rusttype::{point, FontCollection, PositionedGlyph, Scale};
-use std::time::{Duration, Instant};
 use std::collections::HashMap;
+use std::convert::From;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 pub struct WaterfallBuilder<Value> {
     output: String,
@@ -76,7 +76,8 @@ where
             }
         }
 
-        let mut counts = rustcommon_histogram::Histogram::<u64, u64>::new(max_count * max_width, 255);
+        let mut counts =
+            rustcommon_histogram::Histogram::<u64, u64>::new(max_count * max_width, 255);
         for slice in heatmap {
             for bucket in slice.histogram() {
                 let count = u64::from(bucket.count());
@@ -140,7 +141,11 @@ where
         let mut begin = begin_instant;
 
         for (y, slice) in heatmap.into_iter().enumerate() {
-            let slice_start_utc = begin_utc.checked_add_signed(chrono::Duration::from_std(slice.start() - begin_instant).unwrap()).unwrap();
+            let slice_start_utc = begin_utc
+                .checked_add_signed(
+                    chrono::Duration::from_std(slice.start() - begin_instant).unwrap(),
+                )
+                .unwrap();
 
             if slice.start() - begin >= self.interval {
                 let label = format!("{}", slice_start_utc.to_rfc3339());

--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -4,103 +4,116 @@
 
 //! This crate is used to render a waterfall style plot of a heatmap
 
-#[macro_use]
-extern crate log;
-
+use rustcommon_heatmap::*;
+use core::ops::Sub;
+use std::convert::From;
+use chrono::Utc;
+use core::hash::Hash;
 use hsl::HSL;
-use rustcommon_datastructures::*;
 use rusttype::{point, FontCollection, PositionedGlyph, Scale};
-
+use std::time::{Duration, Instant};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::Path;
 
-const MULTIPLIER: u64 = 1_000;
+pub struct WaterfallBuilder<Value> {
+    output: String,
+    labels: HashMap<Value, String>,
+    interval: Duration,
+}
 
-/// Render and save a waterfall from a `Heatmap` to a file. You can specify
-/// `labels` for the value axis. And spacing of labels on the time axis is
-/// specified by the `interval` in nanoseconds.
-///
-/// # Examples
-///
-/// ```
-/// use rustcommon_datastructures::*;
-/// use rustcommon_waterfall::*;
-///
-/// use std::collections::HashMap;
-///
-/// // create a heatmap with appropriate configuration for your dataset
-/// let heatmap = Heatmap::<AtomicU64>::new(1_000_000, 2, 1_000_000, 5_000_000_000);
-///
-/// // add data into the heatmap
-///
-/// // decide on labels and generate waterfall
-/// let mut labels = HashMap::new();
-/// labels.insert(0, "0".to_string());
-/// labels.insert(100, "100".to_string());
-/// labels.insert(1000, "1000".to_string());
-/// labels.insert(10000, "10000".to_string());
-/// labels.insert(100000, "100000".to_string());
-/// save_waterfall(&heatmap, "waterfall.png", labels, 1_000_000_000);
-/// ```
-pub fn save_waterfall<S: ::std::hash::BuildHasher, T: 'static>(
-    heatmap: &Heatmap<T>,
-    file: &str,
-    labels: HashMap<u64, String, S>,
-    interval: u64,
-) where
-    T: Atomic + SaturatingArithmetic + Unsigned + Default,
-    <T as Atomic>::Primitive: Default + PartialEq + Copy,
-    u64: From<<T as Atomic>::Primitive>,
+impl<Value> WaterfallBuilder<Value>
+where
+    Value: Eq + Hash,
+    u64: From<Value>,
 {
-    debug!("saving waterfall");
-    let height = heatmap.slices();
-    let width = heatmap.buckets();
-
-    // create image buffer
-    let mut buffer = ImageBuffer::<ColorRgb>::new(width, height);
-
-    let histogram =
-        Histogram::<AtomicU64>::new(heatmap.highest_count() * MULTIPLIER, 6, None, None);
-    for slice in heatmap {
-        for b in slice.histogram().into_iter() {
-            let weight = MULTIPLIER * u64::from(b.count()) / b.width();
-            if (weight) > 0 {
-                histogram.increment(weight, 1);
-            }
+    pub fn new(target: &str) -> Self {
+        Self {
+            output: target.to_string(),
+            labels: HashMap::new(),
+            interval: Duration::new(60, 0),
         }
     }
 
-    if let Ok(min) = histogram.percentile(0.0) {
-        let mid = histogram.percentile(0.50).unwrap();
-        let high = histogram.percentile(0.99).unwrap();
-        let max = histogram.percentile(1.0).unwrap();
-        let low = 0;
+    pub fn label(mut self, value: Value, label: &str) -> Self {
+        self.labels.insert(value, label.to_string());
+        self
+    }
 
-        debug!(
-            "min: {} low: {} mid: {} high: {} max: {}",
-            min, low, mid, high, max
-        );
+    pub fn build<Count>(self, heatmap: &rustcommon_heatmap::Heatmap<Value, Count>)
+    where
+        Count: rustcommon_heatmap::Counter + PartialOrd + Indexing,
+        Value: rustcommon_heatmap::Indexing + Sub<Output = Value> + Default + PartialOrd,
+        u64: From<Count>,
+        Count: From<u8>,
+    {
+        let now_datetime = Utc::now();
+        let now_instant = Instant::now();
 
-        let mut values: Vec<u64> = labels.keys().cloned().collect();
-        values.sort();
+        let height = heatmap.slices();
+        let width = heatmap.buckets();
+
+        let mut begin_instant = Instant::now();
+
+        let mut buffer = ImageBuffer::<ColorRgb>::new(width, height);
+
+        let mut max_count = 0_u64;
+        let mut max_width = 0_u64;
+        for slice in heatmap {
+            if slice.start() < begin_instant {
+                begin_instant = slice.start();
+            }
+            for bucket in slice.histogram() {
+                let c = u64::from(bucket.count());
+                let w = u64::from(bucket.width());
+                if c > max_count {
+                    max_count = c;
+                }
+                if w > max_width {
+                    max_width = w;
+                }
+            }
+        }
+
+        let mut counts = rustcommon_histogram::Histogram::<u64, u64>::new(max_count * max_width, 255);
+        for slice in heatmap {
+            for bucket in slice.histogram() {
+                let count = u64::from(bucket.count());
+                if count > 0 {
+                    let multiplier = max_width / u64::from(bucket.width());
+                    counts.increment(count * multiplier, 1);
+                }
+            }
+        }
+
+        let low = counts.percentile(1.0).unwrap();
+        let mid = counts.percentile(50.0).unwrap();
+        let high = counts.percentile(99.0).unwrap();
+        let mut labels = HashMap::new();
+        for (k, v) in &self.labels {
+            labels.insert(u64::from(*k), v);
+        }
+
+        let mut label_keys: Vec<u64> = labels.keys().cloned().collect();
+        label_keys.sort();
+
         let mut l = 0;
         for (y, slice) in heatmap.into_iter().enumerate() {
             for (x, b) in slice.histogram().into_iter().enumerate() {
-                let weight = MULTIPLIER * u64::from(b.count()) / b.width();
+                let weight = (max_width / u64::from(b.width())) * u64::from(b.count());
                 let value = color_from_value(weight, low, mid, high);
                 buffer.set_pixel(x, y, value);
             }
         }
 
-        if !values.is_empty() {
+        if !label_keys.is_empty() {
             let y = 0;
             let slice = heatmap.into_iter().next().unwrap();
             for (x, bucket) in slice.histogram().into_iter().enumerate() {
-                let value = bucket.max();
-                if value >= values[l] {
-                    if let Some(label) = labels.get(&values[l]) {
+                let value = u64::from(bucket.value());
+                if value >= label_keys[l] {
+                    if let Some(label) = labels.get(&label_keys[l]) {
                         let overlay = string_buffer(label, 25.0);
                         buffer.overlay(&overlay, x, y);
                         buffer.vertical_line(
@@ -113,34 +126,40 @@ pub fn save_waterfall<S: ::std::hash::BuildHasher, T: 'static>(
                         );
                     }
                     l += 1;
-                    if l >= values.len() {
+                    if l >= label_keys.len() {
                         break;
                     }
                 }
             }
         }
-    }
 
-    let mut begin = heatmap.begin_utc();
-    for (y, slice) in heatmap.into_iter().enumerate() {
-        let slice_begin = slice.begin_utc();
-        if slice_begin - begin >= time::Duration::nanoseconds(interval as i64) {
-            let label = format!("{}", slice_begin.rfc3339());
-            let overlay = string_buffer(&label, 25.0);
-            buffer.overlay(&overlay, 0, y + 2);
-            buffer.horizontal_line(
-                y,
-                ColorRgb {
-                    r: 255,
-                    g: 255,
-                    b: 255,
-                },
-            );
-            begin = slice_begin;
+        let offset = now_instant - begin_instant;
+        let offset = chrono::Duration::from_std(offset).unwrap();
+
+        let begin_utc = now_datetime.checked_sub_signed(offset).unwrap();
+        let mut begin = begin_instant;
+
+        for (y, slice) in heatmap.into_iter().enumerate() {
+            let slice_start_utc = begin_utc.checked_add_signed(chrono::Duration::from_std(slice.start() - begin_instant).unwrap()).unwrap();
+
+            if slice.start() - begin >= self.interval {
+                let label = format!("{}", slice_start_utc.to_rfc3339());
+                let overlay = string_buffer(&label, 25.0);
+                buffer.overlay(&overlay, 0, y + 2);
+                buffer.horizontal_line(
+                    y,
+                    ColorRgb {
+                        r: 255,
+                        g: 255,
+                        b: 255,
+                    },
+                );
+                begin += self.interval;
+            }
         }
-    }
 
-    let _ = buffer.write_png(file);
+        let _ = buffer.write_png(&self.output);
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
Refactoring waterfall to use standalone heatmap crate so it is now
compatible with heatmaps based on std::time::Instant
