### PR TITLE
waterfall: reduce precision of temporary histogram

### DIFF
--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -77,7 +77,7 @@ where
         }
 
         let mut counts =
-            rustcommon_histogram::Histogram::<u64, u64>::new(max_count * max_width, 255);
+            rustcommon_histogram::Histogram::<u64, u64>::new(max_count * max_width, 3);
         for slice in heatmap {
             for bucket in slice.histogram() {
                 let count = u64::from(bucket.count());

--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -76,8 +76,7 @@ where
             }
         }
 
-        let mut counts =
-            rustcommon_histogram::Histogram::<u64, u64>::new(max_count * max_width, 3);
+        let mut counts = rustcommon_histogram::Histogram::<u64, u64>::new(max_count * max_width, 3);
         for slice in heatmap {
             for bucket in slice.histogram() {
                 let count = u64::from(bucket.count());


### PR DESCRIPTION
Reduces the memory utilization of the temporary histogram
by reducing the precision. This prevents excessive memory
usage with large u64 values.