### PR TITLE
improve error types and documentation for histograms and heatmaps

### DIFF
--- a/heatmap/src/error/mod.rs
+++ b/heatmap/src/error/mod.rs
@@ -1,0 +1,26 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use rustcommon_histogram::HistogramError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum HeatmapError {
+    #[error("heatmap contains no samples")]
+    Empty,
+    #[error("invalid percentile")]
+    InvalidPercentile,
+    #[error("value out of range")]
+    OutOfRange,
+}
+
+impl From<HistogramError> for HeatmapError {
+	fn from(other: HistogramError) -> Self {
+		match other {
+			HistogramError::Empty => Self::Empty,
+			HistogramError::InvalidPercentile => Self::InvalidPercentile,
+			HistogramError::OutOfRange => Self::OutOfRange,
+		}
+	}
+}

--- a/heatmap/src/error/mod.rs
+++ b/heatmap/src/error/mod.rs
@@ -16,11 +16,11 @@ pub enum HeatmapError {
 }
 
 impl From<HistogramError> for HeatmapError {
-	fn from(other: HistogramError) -> Self {
-		match other {
-			HistogramError::Empty => Self::Empty,
-			HistogramError::InvalidPercentile => Self::InvalidPercentile,
-			HistogramError::OutOfRange => Self::OutOfRange,
-		}
-	}
+    fn from(other: HistogramError) -> Self {
+        match other {
+            HistogramError::Empty => Self::Empty,
+            HistogramError::InvalidPercentile => Self::InvalidPercentile,
+            HistogramError::OutOfRange => Self::OutOfRange,
+        }
+    }
 }

--- a/heatmap/src/heatmaps/atomic.rs
+++ b/heatmap/src/heatmaps/atomic.rs
@@ -2,13 +2,20 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::Heatmap;
-pub use rustcommon_atomics::*;
-use rustcommon_histogram::AtomicHistogram;
-pub use rustcommon_histogram::{AtomicCounter, Counter, HistogramError, Indexing};
+use crate::*;
+
+use rustcommon_atomics::*;
+use rustcommon_histogram::{AtomicCounter, AtomicHistogram, Counter, Indexing};
+
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
+/// AtomicHeatmaps are concurrent datastructures which store counts for
+/// timestamped values over a configured time range with individual histograms
+/// arranged in a ring buffer. Increments occur in the most recent slice in the
+/// buffer, unless they are newer than that slice may hold. When this happens,
+/// old slices are cleared and reused. This configuration results in a fully
+/// pre-allocated datastructure with concurrent read-write access.
 pub struct AtomicHeatmap<Value, Count> {
     slices: Vec<AtomicHistogram<Value, Count>>,
     current: AtomicUsize,
@@ -24,6 +31,14 @@ where
     u64: From<Value> + From<<Count as Atomic>::Primitive>,
     <Count as Atomic>::Primitive: Copy,
 {
+    /// Create a new `AtomicHeatmap` which can store values up and including the
+    /// `max` while maintaining precision across a wide range of values. The
+    /// `precision` is expressed in the number of significant figures preserved.
+    /// The heatmap will store a histogram for each of the `windows` where each
+    /// window will consist of a duration specified as the `resolution`. The
+    /// combination of the number of windows and resolution places bounds on the
+    /// overall span of time maintained within the heatmap as well as how much
+    /// of the heatmap will be cleared when windows age-out.
     pub fn new(max: Value, precision: u8, windows: usize, resolution: Duration) -> Self {
         let mut slices = Vec::new();
         for _ in 0..windows {
@@ -39,17 +54,44 @@ where
         }
     }
 
+    /// Returns the number of windows stored in the `AtomicHeatmap` 
+    pub fn windows(&self) -> usize {
+        self.slices.len()
+    }
+
+    /// Returns the number of buckets stored within each `Histogram` in the
+    /// `Heatmap`
+    pub fn buckets(&self) -> usize {
+        self.summary.buckets()
+    }
+
+    /// Increment a time-value pair by a specified count
     pub fn increment(&self, time: Instant, value: Value, count: <Count as Atomic>::Primitive) {
         self.tick(time);
         self.slices[self.current.load(Ordering::Relaxed)].increment(value, count);
         self.summary.increment(value, count);
     }
 
-    pub fn percentile(&self, percentile: f64) -> Result<Value, HistogramError> {
+    /// Return the nearest value for the requested percentile (0.0 - 100.0)
+    /// across the total range of samples retained in the `Heatmap`.
+    ///
+    /// Note: since the heatmap stores a distribution across a configured time
+    /// span, sequential calls to fetch the percentile might result in different
+    /// results even without concurrent writers. For instance, you may see a
+    /// 90th percentile that is higher than the 100th percentile depending on
+    /// the timing of calls to this function and the distribution of your data.
+    /// 
+    /// Note: concurrent writes may also effect the value returned by this
+    /// function. Users needing better consistency should ensure that other
+    /// threads are not writing into the heatmap while this function is
+    /// in-progress.
+    pub fn percentile(&self, percentile: f64) -> Result<Value, HeatmapError> {
         self.tick(Instant::now());
-        self.summary.percentile(percentile)
+        self.summary.percentile(percentile).map_err(|e| HeatmapError::from(e))
     }
 
+    // Internal function which handles reuse of older windows to store newer
+    /// values.
     fn tick(&self, time: Instant) {
         loop {
             if time < *self.next_tick.read().unwrap() {
@@ -68,6 +110,13 @@ where
         }
     }
 
+    /// Performs a `Relaxed` load of the current `AtomicHeatmap` allocating and
+    /// returning a non-atomic `Heatmap`.
+    ///
+    /// Note: data may be inconsistent if there are concurrent writes happening
+    /// while the load operation is performed. Users needing better consistency
+    /// should ensure that other threads are not writing into the heatmap while
+    /// this operation is in-progress.
     pub fn load(&self) -> Heatmap<Value, <Count as Atomic>::Primitive>
     where
         Value: Copy + std::ops::Sub<Output = Value>,
@@ -95,22 +144,22 @@ mod tests {
     #[test]
     fn age_out() {
         let mut heatmap = Heatmap::<u64, u64>::new(1_000_000, 2, 1000, Duration::from_millis(1));
-        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+        assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));
         std::thread::sleep(Duration::from_millis(100));
         assert_eq!(heatmap.percentile(0.0), Ok(1));
         std::thread::sleep(Duration::from_millis(2000));
-        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+        assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
 
         let heatmap =
             AtomicHeatmap::<u64, AtomicU64>::new(1_000_000, 2, 1000, Duration::from_millis(1));
-        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+        assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));
         std::thread::sleep(Duration::from_millis(100));
         assert_eq!(heatmap.percentile(0.0), Ok(1));
         std::thread::sleep(Duration::from_millis(2000));
-        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+        assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
     }
 }

--- a/heatmap/src/heatmaps/atomic.rs
+++ b/heatmap/src/heatmaps/atomic.rs
@@ -54,7 +54,7 @@ where
         }
     }
 
-    /// Returns the number of windows stored in the `AtomicHeatmap` 
+    /// Returns the number of windows stored in the `AtomicHeatmap`
     pub fn windows(&self) -> usize {
         self.slices.len()
     }
@@ -80,14 +80,16 @@ where
     /// results even without concurrent writers. For instance, you may see a
     /// 90th percentile that is higher than the 100th percentile depending on
     /// the timing of calls to this function and the distribution of your data.
-    /// 
+    ///
     /// Note: concurrent writes may also effect the value returned by this
     /// function. Users needing better consistency should ensure that other
     /// threads are not writing into the heatmap while this function is
     /// in-progress.
     pub fn percentile(&self, percentile: f64) -> Result<Value, HeatmapError> {
         self.tick(Instant::now());
-        self.summary.percentile(percentile).map_err(|e| HeatmapError::from(e))
+        self.summary
+            .percentile(percentile)
+            .map_err(|e| HeatmapError::from(e))
     }
 
     // Internal function which handles reuse of older windows to store newer

--- a/heatmap/src/heatmaps/mod.rs
+++ b/heatmap/src/heatmaps/mod.rs
@@ -1,0 +1,9 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+mod atomic;
+mod standard;
+
+pub use atomic::AtomicHeatmap;
+pub use standard::Heatmap;

--- a/heatmap/src/heatmaps/standard.rs
+++ b/heatmap/src/heatmaps/standard.rs
@@ -50,7 +50,7 @@ where
         }
     }
 
-    /// Returns the number of windows stored in the `Heatmap` 
+    /// Returns the number of windows stored in the `Heatmap`
     pub fn windows(&self) -> usize {
         self.slices.len()
     }
@@ -78,7 +78,9 @@ where
     /// and the distribution of your data.
     pub fn percentile(&mut self, percentile: f64) -> Result<Value, HeatmapError> {
         self.tick(Instant::now());
-        self.summary.percentile(percentile).map_err(|e| HeatmapError::from(e))
+        self.summary
+            .percentile(percentile)
+            .map_err(|e| HeatmapError::from(e))
     }
 
     /// Internal function which handles reuse of older windows to store newer

--- a/heatmap/src/lib.rs
+++ b/heatmap/src/lib.rs
@@ -2,16 +2,16 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-mod atomic;
-mod slice;
-mod standard;
+mod error;
+mod heatmaps;
+mod window;
 
-pub use atomic::AtomicHeatmap;
-pub use slice::Slice;
-pub use standard::Heatmap;
+pub use error::HeatmapError;
+pub use heatmaps::{AtomicHeatmap, Heatmap};
+pub use window::Window;
 
 pub use rustcommon_atomics::{Atomic, AtomicU16, AtomicU32, AtomicU64, AtomicU8};
-pub use rustcommon_histogram::{AtomicCounter, Counter, HistogramError, Indexing};
+pub use rustcommon_histogram::{AtomicCounter, Counter, Indexing};
 
 #[cfg(test)]
 mod tests {
@@ -22,22 +22,22 @@ mod tests {
     #[test]
     fn age_out() {
         let mut heatmap = Heatmap::<u64, u64>::new(1_000_000, 2, 1000, Duration::from_millis(1));
-        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+        assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));
         std::thread::sleep(Duration::from_millis(100));
         assert_eq!(heatmap.percentile(0.0), Ok(1));
         std::thread::sleep(Duration::from_millis(2000));
-        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+        assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
 
         let heatmap =
             AtomicHeatmap::<u64, AtomicU64>::new(1_000_000, 2, 1000, Duration::from_millis(1));
-        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+        assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));
         std::thread::sleep(Duration::from_millis(100));
         assert_eq!(heatmap.percentile(0.0), Ok(1));
         std::thread::sleep(Duration::from_millis(2000));
-        assert_eq!(heatmap.percentile(0.0), Err(HistogramError::Empty));
+        assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
     }
 }

--- a/heatmap/src/window/mod.rs
+++ b/heatmap/src/window/mod.rs
@@ -1,13 +1,13 @@
 use rustcommon_histogram::Histogram;
 use std::time::Instant;
 
-pub struct Slice<Value, Count> {
+pub struct Window<Value, Count> {
     pub(crate) start: Instant,
     pub(crate) stop: Instant,
     pub(crate) histogram: Histogram<Value, Count>,
 }
 
-impl<Value, Count> Slice<Value, Count> {
+impl<Value, Count> Window<Value, Count> {
     pub fn start(&self) -> Instant {
         self.start
     }

--- a/histogram/src/bucket/mod.rs
+++ b/histogram/src/bucket/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::Counter;
 
-/// A `Bucket` stores a count across a range of values
+/// A bucket stores a count across a range of values
 pub struct Bucket<Value, Count> {
     pub(crate) min: Value,
     pub(crate) max: Value,

--- a/histogram/src/counter/mod.rs
+++ b/histogram/src/counter/mod.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+/// A trait which is used to restrict the types that may be used to store counts
+/// for atomic types.
 pub trait AtomicCounter:
     rustcommon_atomics::Atomic
     + rustcommon_atomics::Unsigned
@@ -16,6 +18,8 @@ impl AtomicCounter for rustcommon_atomics::AtomicU32 {}
 impl AtomicCounter for rustcommon_atomics::AtomicU64 {}
 impl AtomicCounter for rustcommon_atomics::AtomicUsize {}
 
+/// A trait which is used to restrict the types that may be used to store counts
+/// for non-atomic types.
 pub trait Counter: Default + Copy {
     fn saturating_add(&mut self, value: Self);
     fn saturating_sub(&mut self, value: Self);

--- a/histogram/src/error/mod.rs
+++ b/histogram/src/error/mod.rs
@@ -4,12 +4,14 @@
 
 use thiserror::Error;
 
+/// Possible errors returned by operations on a histogram.
 #[derive(Error, Debug, PartialEq)]
 pub enum HistogramError {
     #[error("histogram contains no samples")]
     /// The histogram contains no samples.
     Empty,
     #[error("invalid percentile")]
+    /// The provided percentile is outside of the range 0.0 - 100.0 (inclusive)
     InvalidPercentile,
     #[error("value out of range")]
     /// The requested value is out of range.

--- a/histogram/src/histograms/standard.rs
+++ b/histogram/src/histograms/standard.rs
@@ -5,7 +5,7 @@
 use crate::{Bucket, Counter, HistogramError, Indexing};
 
 #[derive(Clone)]
-/// A histogram type which follows normal ownership rules.
+/// A histogram structure which stores counts for a range of values.
 pub struct Histogram<Value, Count> {
     buckets: Vec<Count>,
     exact: Value,
@@ -65,7 +65,7 @@ where
         }
     }
 
-    /// Clear all counts
+    /// Clear all counts.
     pub fn clear(&mut self) {
         for i in 0..self.buckets.len() {
             self.buckets[i] = Count::default();
@@ -73,6 +73,7 @@ where
         self.too_high = Count::default();
     }
 
+    /// Return the number of buckets stored within the histogram.
     pub fn buckets(&self) -> usize {
         self.buckets.len()
     }
@@ -114,6 +115,7 @@ where
         Err(HistogramError::OutOfRange)
     }
 
+    /// Internal function to get a bucket by index
     fn get_bucket(&self, index: usize) -> Option<Bucket<Value, Count>> {
         if let Ok(min) = Value::get_min_value(
             index,
@@ -150,6 +152,7 @@ where
         }
     }
 
+    /// Subtracts another histogram from this histogram
     pub fn sub_assign(&mut self, other: &Self) {
         for bucket in other {
             self.decrement(bucket.value, bucket.count);

--- a/histogram/src/indexing/mod.rs
+++ b/histogram/src/indexing/mod.rs
@@ -7,11 +7,19 @@ mod u32;
 mod u64;
 mod u8;
 
+/// Used to restrict what types may be used as values for histograms. Also used
+/// to provide a unified interface for performing type-specific operations such
+/// as indexing into the internal storage, converting an index back to bucket
+/// values, and calculating configuration parameters for the histogram.
 pub trait Indexing
 where
     Self: Sized + Copy,
 {
+    /// Calculate a bucket index for a given value and configuration.
     fn get_index(value: Self, max: Self, exact: Self, precision: u8) -> Result<usize, ()>;
+
+    /// Calculate the minimum stored value for a given bucket index and
+    /// configuration.
     fn get_min_value(
         index: usize,
         buckets: usize,
@@ -19,6 +27,8 @@ where
         exact: Self,
         precision: u8,
     ) -> Result<Self, ()>;
+
+    /// Calculate the nominal value for a given bucket index and configuration.
     fn get_value(
         index: usize,
         buckets: usize,
@@ -27,6 +37,8 @@ where
         precision: u8,
     ) -> Result<Self, ()>;
 
+    /// Calculate the exclusive upper bound for a given bucket index and
+    /// configuration.
     fn get_max_value(
         index: usize,
         buckets: usize,
@@ -35,6 +47,10 @@ where
         precision: u8,
     ) -> Result<Self, ()>;
 
+    /// Used to reduce the configured precision based on the type.
     fn constrain_precision(precision: u8) -> u8;
+
+    /// Used to calculate the highest value which is stored exactly for a given
+    /// type and configuration.
     fn constrain_exact(max: Self, precision: u8) -> Self;
 }

--- a/histogram/src/indexing/u32.rs
+++ b/histogram/src/indexing/u32.rs
@@ -1,3 +1,7 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 impl crate::Indexing for u32 {
     fn constrain_precision(precision: u8) -> u8 {
         if precision == 0 {

--- a/histogram/src/indexing/u64.rs
+++ b/histogram/src/indexing/u64.rs
@@ -1,3 +1,7 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 impl crate::Indexing for u64 {
     fn constrain_precision(precision: u8) -> u8 {
         if precision == 0 {

--- a/histogram/src/indexing/u8.rs
+++ b/histogram/src/indexing/u8.rs
@@ -1,3 +1,7 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 impl crate::Indexing for u8 {
     fn constrain_precision(precision: u8) -> u8 {
         if precision == 0 {

--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -51,7 +51,7 @@ where
         let now_datetime = Utc::now();
         let now_instant = Instant::now();
 
-        let height = heatmap.slices();
+        let height = heatmap.windows();
         let width = heatmap.buckets();
 
         let mut begin_instant = Instant::now();


### PR DESCRIPTION
Improve the error types and documentation for histograms and
heatmaps.

Adds a new `HeatmapError` type.
