### PR TITLE
waterfall: add bounds checking to text rendering

### DIFF
--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -197,11 +197,11 @@ fn render_text(string: &str, size: f32, x_pos: usize, y_pos: usize, buf: &mut Rg
                 let x = (x as i32 + bb.min.x) as usize;
                 let y = (y as i32 + bb.min.y) as usize;
                 if v > 0.25 {
-                    buf.put_pixel(
-                        (x + x_pos).try_into().unwrap(),
-                        (y + y_pos).try_into().unwrap(),
-                        Rgb([255, 255, 255]),
-                    );
+                    let x = (x + x_pos).try_into().unwrap();
+                    let y = (y + y_pos).try_into().unwrap();
+                    if x < buf.width() && y < buf.height() {
+                        buf.put_pixel(x, y, Rgb([255, 255, 255]));
+                    }
                 }
             })
         }


### PR DESCRIPTION
Possible to have text overflow beyond the buffer, this change adds
checking before attempting to set the pixel value to make sure it
is within the image bounds.
