### PR TITLE
logger: remove log level message on initialization

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -39,7 +39,6 @@ impl Logger {
     }
 
     pub fn init(self) -> Result<(), SetLoggerError> {
-        println!("log level: {:?}", self.level);
         let level = self.level;
         log::set_boxed_logger(Box::new(self)).map(|()| log::set_max_level(level.to_level_filter()))
     }


### PR DESCRIPTION
Removes the log level message on logger initialization.
