### PR TITLE
waterfall: add smoothing

### DIFF
--- a/waterfall/examples/simulator.rs
+++ b/waterfall/examples/simulator.rs
@@ -102,6 +102,18 @@ pub fn simulate(shape: Shape) {
                 .scale(*scale)
                 .palette(*palette)
                 .build(&heatmap);
+
+            let filename = format!("{}_{}_{}_smooth.png", shape_name, palette_name, scale_name);
+
+            WaterfallBuilder::new(&filename)
+                .label(100, "100")
+                .label(1000, "1000")
+                .label(10000, "10000")
+                .label(100000, "100000")
+                .scale(*scale)
+                .palette(*palette)
+                .smooth(Some(1.0))
+                .build(&heatmap);
         }
     }
 }

--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -35,6 +35,7 @@ pub struct WaterfallBuilder<Value> {
     palette: Palette,
     interval: Duration,
     scale: Scale,
+    smooth: Option<f32>,
 }
 
 impl<Value> WaterfallBuilder<Value>
@@ -49,24 +50,63 @@ where
             palette: Palette::Classic,
             interval: Duration::new(60, 0),
             scale: Scale::Linear,
+            smooth: None,
         }
     }
 
+    /// Adds a label to the horizontal axis at the specified value
     pub fn label(mut self, value: Value, label: &str) -> Self {
         self.labels.insert(value, label.to_string());
         self
     }
 
+    /// Sets the color palette for the waterfall
     pub fn palette(mut self, palette: Palette) -> Self {
         self.palette = palette;
         self
     }
 
+    /// Select a color scale for the waterfall
     pub fn scale(mut self, scale: Scale) -> Self {
         self.scale = scale;
         self
     }
 
+    /// Set a smoothing on the waterfall which is applied before colorization
+    pub fn smooth(mut self, sigma: Option<f32>) -> Self {
+        self.smooth = sigma;
+        self
+    }
+
+    // get the scaled weight for a bucket count / width
+    fn weight(&self, count: u64, width: u64) -> f64 {
+        match self.scale {
+            Scale::Linear => count as f64 / width as f64,
+            Scale::Logarithmic => (count as f64 / width as f64).log2(),
+        }
+    }
+
+    // find the bucket with the highest weight
+    fn max_weight<Count>(&self, heatmap: &rustcommon_heatmap::Heatmap<Value, Count>) -> f64
+    where
+        Count: rustcommon_heatmap::Counter + PartialOrd + Indexing,
+        Value: rustcommon_heatmap::Indexing + Sub<Output = Value> + Default + PartialOrd,
+        u64: From<Count>,
+        Count: From<u8>,
+    {
+        let mut max_weight = 0.0;
+        for slice in heatmap {
+            for b in slice.histogram() {
+                let weight = self.weight(u64::from(b.count()), u64::from(b.width()));
+                if weight > max_weight {
+                    max_weight = weight;
+                }
+            }
+        }
+        max_weight
+    }
+
+    /// Generate the waterfall from the provided heatmap
     pub fn build<Count>(self, heatmap: &rustcommon_heatmap::Heatmap<Value, Count>)
     where
         Count: rustcommon_heatmap::Counter + PartialOrd + Indexing,
@@ -85,21 +125,7 @@ where
         // need to know the start time of the heatmap
         let begin_instant = heatmap.into_iter().next().unwrap().start();
 
-        // find the bucket with the highest weight
-        let mut max_weight = 0.0;
-        for slice in heatmap {
-            for b in slice.histogram() {
-                let weight = match self.scale {
-                    Scale::Linear => u64::from(b.count()) as f64 / u64::from(b.width()) as f64,
-                    Scale::Logarithmic => {
-                        (u64::from(b.count()) as f64 / u64::from(b.width()) as f64).log2()
-                    }
-                };
-                if weight > max_weight {
-                    max_weight = weight;
-                }
-            }
-        }
+        let max_weight = self.max_weight(heatmap);
 
         let colors = match self.palette {
             Palette::Classic => CLASSIC,
@@ -116,23 +142,48 @@ where
 
         let mut l = 0;
 
-        // set the pixels in the buffer
-        for (y, slice) in heatmap.into_iter().enumerate() {
-            for (x, b) in slice.histogram().into_iter().enumerate() {
-                let weight = match self.scale {
-                    Scale::Linear => u64::from(b.count()) as f64 / u64::from(b.width()) as f64,
-                    Scale::Logarithmic => {
-                        (u64::from(b.count()) as f64 / u64::from(b.width()) as f64).log2()
-                    }
-                };
-                let scaled_weight = weight / max_weight;
-                let index = (scaled_weight * (colors.len() - 1) as f64).round() as usize;
-                let color = colors[index];
-                buf.put_pixel(
-                    x.try_into().unwrap(),
-                    y.try_into().unwrap(),
-                    Rgb([color.r, color.g, color.b]),
-                );
+        if let Some(sigma) = self.smooth {
+            // NOTE: this won't work properly if the palette is > 256 colors
+
+            // build grayscale buffer
+            for (y, slice) in heatmap.into_iter().enumerate() {
+                for (x, b) in slice.histogram().into_iter().enumerate() {
+                    let weight = self.weight(u64::from(b.count()), u64::from(b.width()));
+                    let scaled_weight = weight / max_weight;
+                    let index = (scaled_weight * (colors.len() - 1) as f64).round() as u8;
+                    buf.put_pixel(
+                        x.try_into().unwrap(),
+                        y.try_into().unwrap(),
+                        Rgb([index, index, index]),
+                    );
+                }
+            }
+
+            // apply a blur to smooth
+            buf = image::imageops::blur(&buf, sigma);
+
+            // colorize the buffer
+            for x in 0..buf.width() {
+                for y in 0..buf.height() {
+                    let index = buf.get_pixel(x, y).0[0];
+                    let color = colors[index as usize];
+                    buf.put_pixel(x, y, Rgb([color.r, color.g, color.b]));
+                }
+            }
+        } else {
+            // set the pixels in the buffer
+            for (y, slice) in heatmap.into_iter().enumerate() {
+                for (x, b) in slice.histogram().into_iter().enumerate() {
+                    let weight = self.weight(u64::from(b.count()), u64::from(b.width()));
+                    let scaled_weight = weight / max_weight;
+                    let index = (scaled_weight * (colors.len() - 1) as f64).round() as usize;
+                    let color = colors[index];
+                    buf.put_pixel(
+                        x.try_into().unwrap(),
+                        y.try_into().unwrap(),
+                        Rgb([color.r, color.g, color.b]),
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Adds smoothing option to the waterfall which works by applying an
image blur before colorizing the image buffer. This may be useful
for some data distributions to help reduce artifacting across
bucket width changes at the cost of reducing the effective detail
within the waterfall and potential to introduce other artifacts.

Adds smoothed versions to the simulator to help illustrate the
differences.
