### PR TITLE
histogram: improve indexing performance

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -11,3 +11,10 @@ repository = "https://github.com/twitter/rustcommon"
 [dependencies]
 rustcommon-atomics = { path = "../atomics" }
 thiserror = "1.0.20"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "standard"
+harness = false

--- a/histogram/benches/standard.rs
+++ b/histogram/benches/standard.rs
@@ -1,101 +1,187 @@
-use rustcommon_histogram::Histogram;
 use criterion::{criterion_group, criterion_main, Criterion};
+use rustcommon_histogram::Histogram;
 
 fn increment_u8(c: &mut Criterion) {
-	let max = 100;
-	
-	let mut histogram = Histogram::<u8, u8>::new(max, 1);
-    c.bench_function("Histogram::<u8, u8>::increment() precision 1 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u8, u8>::increment() precision 1 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    let max = 100;
+
+    let mut histogram = Histogram::<u8, u8>::new(max, 1);
+    c.bench_function("Histogram::<u8, u8>::increment() precision 1 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u8, u8>::increment() precision 1 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u8, u8>::new(max, 2);
-    c.bench_function("Histogram::<u8, u8>::increment() precision 2 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u8, u8>::increment() precision 2 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u8, u8>::increment() precision 2 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u8, u8>::increment() precision 2 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u8, u8>::new(max, 3);
-    c.bench_function("Histogram::<u8, u8>::increment() precision 3 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u8, u8>::increment() precision 3 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u8, u8>::increment() precision 3 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u8, u8>::increment() precision 3 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 }
 
 fn increment_u16(c: &mut Criterion) {
-	let max = 10_000;
-	
-	let mut histogram = Histogram::<u16, u16>::new(max, 1);
-    c.bench_function("Histogram::<u16, u16>::increment() precision 1 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u16, u16>::increment() precision 1 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    let max = 10_000;
+
+    let mut histogram = Histogram::<u16, u16>::new(max, 1);
+    c.bench_function("Histogram::<u16, u16>::increment() precision 1 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u16, u16>::increment() precision 1 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u16, u16>::new(max, 2);
-    c.bench_function("Histogram::<u16, u16>::increment() precision 2 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u16, u16>::increment() precision 2 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u16, u16>::increment() precision 2 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u16, u16>::increment() precision 2 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u16, u16>::new(max, 3);
-    c.bench_function("Histogram::<u16, u16>::increment() precision 3 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u16, u16>::increment() precision 3 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u16, u16>::increment() precision 3 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u16, u16>::increment() precision 3 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u16, u16>::new(max, 4);
-    c.bench_function("Histogram::<u16, u16>::increment() precision 4 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u16, u16>::increment() precision 4 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u16, u16>::increment() precision 4 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u16, u16>::increment() precision 4 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u16, u16>::new(max, 5);
-    c.bench_function("Histogram::<u16, u16>::increment() precision 5 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u16, u16>::increment() precision 5 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u16, u16>::increment() precision 5 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u16, u16>::increment() precision 5 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 }
 
 fn increment_u32(c: &mut Criterion) {
-	let max = 1_000_000_000;
-	
-	let mut histogram = Histogram::<u32, u32>::new(max, 1);
-    c.bench_function("Histogram::<u32, u32>::increment() precision 1 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u32, u32>::increment() precision 1 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    let max = 1_000_000_000;
+
+    let mut histogram = Histogram::<u32, u32>::new(max, 1);
+    c.bench_function("Histogram::<u32, u32>::increment() precision 1 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u32, u32>::increment() precision 1 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u32, u32>::new(max, 2);
-    c.bench_function("Histogram::<u32, u32>::increment() precision 2 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u32, u32>::increment() precision 2 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 2 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u32, u32>::increment() precision 2 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u32, u32>::new(max, 3);
-    c.bench_function("Histogram::<u32, u32>::increment() precision 3 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u32, u32>::increment() precision 3 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 3 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u32, u32>::increment() precision 3 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u32, u32>::new(max, 4);
-    c.bench_function("Histogram::<u32, u32>::increment() precision 4 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u32, u32>::increment() precision 4 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 4 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u32, u32>::increment() precision 4 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u32, u32>::new(max, 5);
-    c.bench_function("Histogram::<u32, u32>::increment() precision 5 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u32, u32>::increment() precision 5 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 5 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u32, u32>::increment() precision 5 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u32, u32>::new(max, 6);
-    c.bench_function("Histogram::<u32, u32>::increment() precision 6 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u32, u32>::increment() precision 6 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 6 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u32, u32>::increment() precision 6 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 }
 
 fn increment_u64(c: &mut Criterion) {
-	let max = 1_000_000_000;
-	
-	let mut histogram = Histogram::<u64, u64>::new(max, 1);
-    c.bench_function("Histogram::<u64, u64>::increment() precision 1 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u64, u64>::increment() precision 1 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    let max = 1_000_000_000;
+
+    let mut histogram = Histogram::<u64, u64>::new(max, 1);
+    c.bench_function("Histogram::<u64, u64>::increment() precision 1 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u64, u64>::increment() precision 1 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u64, u64>::new(max, 2);
-    c.bench_function("Histogram::<u64, u64>::increment() precision 2 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u64, u64>::increment() precision 2 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 2 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u64, u64>::increment() precision 2 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u64, u64>::new(max, 3);
-    c.bench_function("Histogram::<u64, u64>::increment() precision 3 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u64, u64>::increment() precision 3 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 3 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u64, u64>::increment() precision 3 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u64, u64>::new(max, 4);
-    c.bench_function("Histogram::<u64, u64>::increment() precision 4 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u64, u64>::increment() precision 4 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 4 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u64, u64>::increment() precision 4 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u64, u64>::new(max, 5);
-    c.bench_function("Histogram::<u64, u64>::increment() precision 5 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u64, u64>::increment() precision 5 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 5 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u64, u64>::increment() precision 5 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 
     let mut histogram = Histogram::<u64, u64>::new(max, 6);
-    c.bench_function("Histogram::<u64, u64>::increment() precision 6 min", |b| b.iter(|| histogram.increment(1, 1) ));
-    c.bench_function("Histogram::<u64, u64>::increment() precision 6 max", |b| b.iter(|| histogram.increment(max, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 6 min", |b| {
+        b.iter(|| histogram.increment(1, 1))
+    });
+    c.bench_function("Histogram::<u64, u64>::increment() precision 6 max", |b| {
+        b.iter(|| histogram.increment(max, 1))
+    });
 }
 
-criterion_group!(benches, increment_u8, increment_u16, increment_u32, increment_u64);
+criterion_group!(
+    benches,
+    increment_u8,
+    increment_u16,
+    increment_u32,
+    increment_u64
+);
 criterion_main!(benches);

--- a/histogram/benches/standard.rs
+++ b/histogram/benches/standard.rs
@@ -1,0 +1,101 @@
+use rustcommon_histogram::Histogram;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn increment_u8(c: &mut Criterion) {
+	let max = 100;
+	
+	let mut histogram = Histogram::<u8, u8>::new(max, 1);
+    c.bench_function("Histogram::<u8, u8>::increment() precision 1 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u8, u8>::increment() precision 1 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u8, u8>::new(max, 2);
+    c.bench_function("Histogram::<u8, u8>::increment() precision 2 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u8, u8>::increment() precision 2 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u8, u8>::new(max, 3);
+    c.bench_function("Histogram::<u8, u8>::increment() precision 3 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u8, u8>::increment() precision 3 max", |b| b.iter(|| histogram.increment(max, 1) ));
+}
+
+fn increment_u16(c: &mut Criterion) {
+	let max = 10_000;
+	
+	let mut histogram = Histogram::<u16, u16>::new(max, 1);
+    c.bench_function("Histogram::<u16, u16>::increment() precision 1 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u16, u16>::increment() precision 1 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u16, u16>::new(max, 2);
+    c.bench_function("Histogram::<u16, u16>::increment() precision 2 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u16, u16>::increment() precision 2 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u16, u16>::new(max, 3);
+    c.bench_function("Histogram::<u16, u16>::increment() precision 3 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u16, u16>::increment() precision 3 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u16, u16>::new(max, 4);
+    c.bench_function("Histogram::<u16, u16>::increment() precision 4 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u16, u16>::increment() precision 4 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u16, u16>::new(max, 5);
+    c.bench_function("Histogram::<u16, u16>::increment() precision 5 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u16, u16>::increment() precision 5 max", |b| b.iter(|| histogram.increment(max, 1) ));
+}
+
+fn increment_u32(c: &mut Criterion) {
+	let max = 1_000_000_000;
+	
+	let mut histogram = Histogram::<u32, u32>::new(max, 1);
+    c.bench_function("Histogram::<u32, u32>::increment() precision 1 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 1 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u32, u32>::new(max, 2);
+    c.bench_function("Histogram::<u32, u32>::increment() precision 2 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 2 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u32, u32>::new(max, 3);
+    c.bench_function("Histogram::<u32, u32>::increment() precision 3 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 3 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u32, u32>::new(max, 4);
+    c.bench_function("Histogram::<u32, u32>::increment() precision 4 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 4 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u32, u32>::new(max, 5);
+    c.bench_function("Histogram::<u32, u32>::increment() precision 5 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 5 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u32, u32>::new(max, 6);
+    c.bench_function("Histogram::<u32, u32>::increment() precision 6 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u32, u32>::increment() precision 6 max", |b| b.iter(|| histogram.increment(max, 1) ));
+}
+
+fn increment_u64(c: &mut Criterion) {
+	let max = 1_000_000_000;
+	
+	let mut histogram = Histogram::<u64, u64>::new(max, 1);
+    c.bench_function("Histogram::<u64, u64>::increment() precision 1 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 1 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u64, u64>::new(max, 2);
+    c.bench_function("Histogram::<u64, u64>::increment() precision 2 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 2 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u64, u64>::new(max, 3);
+    c.bench_function("Histogram::<u64, u64>::increment() precision 3 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 3 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u64, u64>::new(max, 4);
+    c.bench_function("Histogram::<u64, u64>::increment() precision 4 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 4 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u64, u64>::new(max, 5);
+    c.bench_function("Histogram::<u64, u64>::increment() precision 5 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 5 max", |b| b.iter(|| histogram.increment(max, 1) ));
+
+    let mut histogram = Histogram::<u64, u64>::new(max, 6);
+    c.bench_function("Histogram::<u64, u64>::increment() precision 6 min", |b| b.iter(|| histogram.increment(1, 1) ));
+    c.bench_function("Histogram::<u64, u64>::increment() precision 6 max", |b| b.iter(|| histogram.increment(max, 1) ));
+}
+
+criterion_group!(benches, increment_u8, increment_u16, increment_u32, increment_u64);
+criterion_main!(benches);

--- a/histogram/src/indexing/u16.rs
+++ b/histogram/src/indexing/u16.rs
@@ -27,7 +27,17 @@ impl crate::Indexing for u16 {
         } else if value <= exact {
             Ok(value.into())
         } else {
-            let power = (value as f64).log10().floor() as u16;
+            let power = if value < 10 {
+                0
+            } else if value < 100 {
+                1
+            } else if value < 1_000 {
+                2
+            } else if value < 10_000 {
+                3
+            } else {
+                4
+            };
             let denominator = 10_usize.pow((power - precision as u16 + 1).into());
             let power_offset =
                 (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;

--- a/histogram/src/indexing/u32.rs
+++ b/histogram/src/indexing/u32.rs
@@ -27,7 +27,28 @@ impl crate::Indexing for u32 {
         } else if value <= exact {
             Ok(value as usize)
         } else {
-            let power = (value as f64).log10().floor() as u16;
+            let power = if value < 10 {
+                0
+            } else if value < 100 {
+                1
+            } else if value < 1_000 {
+                2
+            } else if value < 10_000 {
+                3
+            } else if value < 100_000 {
+                4
+            } else if value < 1_000_000 {
+                5
+            } else if value < 10_000_000 {
+                6
+            } else if value < 100_000_000 {
+                7
+            } else if value < 1_000_000_000 {
+                8
+            } else {
+                9
+            };
+            // let power = (value as f64).log10().floor() as u16;
             let denominator = 10_usize.pow((power - precision as u16 + 1).into());
             let power_offset =
                 (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;

--- a/histogram/src/indexing/u64.rs
+++ b/histogram/src/indexing/u64.rs
@@ -27,7 +27,48 @@ impl crate::Indexing for u64 {
         } else if value <= exact {
             Ok(value as usize)
         } else {
-            let power = (value as f64).log10().floor() as u16;
+            let power = if value < 10 {
+                0
+            } else if value < 100 {
+                1
+            } else if value < 1_000 {
+                2
+            } else if value < 10_000 {
+                3
+            } else if value < 100_000 {
+                4
+            } else if value < 1_000_000 {
+                5
+            } else if value < 10_000_000 {
+                6
+            } else if value < 100_000_000 {
+                7
+            } else if value < 1_000_000_000 {
+                8
+            } else if value < 10_000_000_000 {
+                9
+            } else if value < 100_000_000_000 {
+                10
+            } else if value < 1_000_000_000_000 {
+                11
+            } else if value < 10_000_000_000_000 {
+                12
+            } else if value < 100_000_000_000_000 {
+                13
+            } else if value < 1_000_000_000_000_000 {
+                14
+            } else if value < 10_000_000_000_000_000 {
+                15
+            } else if value < 100_000_000_000_000_000 {
+                16
+            } else if value < 1_000_000_000_000_000_000 {
+                17
+            } else if value < 10_000_000_000_000_000_000 {
+                18
+            } else {
+                19
+            };
+            // let power = (value as f64).log10().floor() as u16;
             let denominator = 10_usize.pow((power - precision as u16 + 1).into());
             let power_offset =
                 (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;

--- a/histogram/src/indexing/u8.rs
+++ b/histogram/src/indexing/u8.rs
@@ -27,7 +27,13 @@ impl crate::Indexing for u8 {
         } else if value <= exact {
             Ok(value.into())
         } else {
-            let power = (value as f64).log10().floor() as u8;
+            let power = if value < 10 {
+                0
+            } else if value < 100 {
+                1
+            } else {
+                2
+            };
             let denominator = 10_usize.pow((power - precision + 1).into());
             let power_offset =
                 (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;


### PR DESCRIPTION
Improves the indexing performance of the histogram implementations
by removing the `log10()`. Results in ~60% reduction in time to
increment large values.
