### PR TITLE
histogram: improve performance of `sub_assign()`

### DIFF
--- a/histogram/benches/standard.rs
+++ b/histogram/benches/standard.rs
@@ -177,11 +177,23 @@ fn increment_u64(c: &mut Criterion) {
     });
 }
 
+fn subtract(c: &mut Criterion) {
+    let max = 1_000_000_000;
+
+    let mut alpha = Histogram::<u64, u64>::new(max, 6);
+    let bravo = alpha.clone();
+
+    c.bench_function("Histogram::<u64, u64>::increment() precision 6 min", |b| {
+        b.iter(|| alpha.sub_assign(&bravo))
+    });
+}
+
 criterion_group!(
     benches,
     increment_u8,
     increment_u16,
     increment_u32,
-    increment_u64
+    increment_u64,
+    subtract,
 );
 criterion_main!(benches);

--- a/histogram/src/histograms/standard.rs
+++ b/histogram/src/histograms/standard.rs
@@ -154,8 +154,16 @@ where
 
     /// Subtracts another histogram from this histogram
     pub fn sub_assign(&mut self, other: &Self) {
-        for bucket in other {
-            self.decrement(bucket.value, bucket.count);
+        if u64::from(self.max) == u64::from(other.max) && self.precision == other.precision {
+            // fast path when histograms have same configuration
+            for i in 0..self.buckets.len() {
+                self.buckets[i].saturating_sub(other.buckets[i]);
+            }
+        } else {
+            // slow path if we need to calculate appropriate index for each bucket
+            for bucket in other {
+                self.decrement(bucket.value, bucket.count);
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a fast-path for `sub_assign()` which is used heavily in the
heatmap crate. This fast path reduces the runtime of the operation
from ~200ms to < 10ms for the case added in the benchmark.
