### PR TITLE
histogram: improve performance for atomic histogram sub_assign

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -18,3 +18,7 @@ criterion = "0.3"
 [[bench]]
 name = "standard"
 harness = false
+
+[[bench]]
+name = "atomic"
+harness = false

--- a/histogram/benches/atomic.rs
+++ b/histogram/benches/atomic.rs
@@ -11,10 +11,12 @@ fn increment_u8(c: &mut Criterion) {
     for precision in 1..=3 {
         let histogram = AtomicHistogram::<u8, AtomicU8>::new(max, precision);
         group.throughput(Throughput::Elements(1));
-        group.bench_function(BenchmarkId::new("min/precision", precision),
-            |b| { b.iter(|| histogram.increment(1, 1)) });
-        group.bench_function(BenchmarkId::new("max/precision", precision),
-            |b| { b.iter(|| histogram.increment(max, 1)) });
+        group.bench_function(BenchmarkId::new("min/precision", precision), |b| {
+            b.iter(|| histogram.increment(1, 1))
+        });
+        group.bench_function(BenchmarkId::new("max/precision", precision), |b| {
+            b.iter(|| histogram.increment(max, 1))
+        });
     }
 }
 
@@ -26,10 +28,12 @@ fn increment_u16(c: &mut Criterion) {
     for precision in 1..=5 {
         let histogram = AtomicHistogram::<u16, AtomicU16>::new(max, precision);
         group.throughput(Throughput::Elements(1));
-        group.bench_function(BenchmarkId::new("min/precision", precision),
-            |b| { b.iter(|| histogram.increment(1, 1)) });
-        group.bench_function(BenchmarkId::new("max/precision", precision),
-            |b| { b.iter(|| histogram.increment(max, 1)) });
+        group.bench_function(BenchmarkId::new("min/precision", precision), |b| {
+            b.iter(|| histogram.increment(1, 1))
+        });
+        group.bench_function(BenchmarkId::new("max/precision", precision), |b| {
+            b.iter(|| histogram.increment(max, 1))
+        });
     }
 }
 
@@ -41,10 +45,12 @@ fn increment_u32(c: &mut Criterion) {
     for precision in 1..=6 {
         let histogram = AtomicHistogram::<u32, AtomicU32>::new(max, precision);
         group.throughput(Throughput::Elements(1));
-        group.bench_function(BenchmarkId::new("min/precision", precision),
-            |b| { b.iter(|| histogram.increment(1, 1)) });
-        group.bench_function(BenchmarkId::new("max/precision", precision),
-            |b| { b.iter(|| histogram.increment(max, 1)) });
+        group.bench_function(BenchmarkId::new("min/precision", precision), |b| {
+            b.iter(|| histogram.increment(1, 1))
+        });
+        group.bench_function(BenchmarkId::new("max/precision", precision), |b| {
+            b.iter(|| histogram.increment(max, 1))
+        });
     }
 }
 
@@ -56,10 +62,12 @@ fn increment_u64(c: &mut Criterion) {
     for precision in 1..=6 {
         let histogram = AtomicHistogram::<u64, AtomicU64>::new(max, precision);
         group.throughput(Throughput::Elements(1));
-        group.bench_function(BenchmarkId::new("min/precision", precision),
-            |b| { b.iter(|| histogram.increment(1, 1)) });
-        group.bench_function(BenchmarkId::new("max/precision", precision),
-            |b| { b.iter(|| histogram.increment(max, 1)) });
+        group.bench_function(BenchmarkId::new("min/precision", precision), |b| {
+            b.iter(|| histogram.increment(1, 1))
+        });
+        group.bench_function(BenchmarkId::new("max/precision", precision), |b| {
+            b.iter(|| histogram.increment(max, 1))
+        });
     }
 }
 
@@ -71,8 +79,9 @@ fn sub_assign_u64(c: &mut Criterion) {
     for precision in 1..=6 {
         let alpha = AtomicHistogram::<u64, AtomicU64>::new(max, precision);
         let bravo = AtomicHistogram::<u64, AtomicU64>::new(max, precision);
-        group.bench_function(BenchmarkId::new("precision", precision),
-            |b| { b.iter(|| alpha.sub_assign(&bravo)) });
+        group.bench_function(BenchmarkId::new("precision", precision), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
     }
 }
 

--- a/histogram/benches/atomic.rs
+++ b/histogram/benches/atomic.rs
@@ -1,15 +1,15 @@
-use criterion::Throughput;
 use criterion::BenchmarkId;
+use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Criterion};
-use rustcommon_histogram::Histogram;
+use rustcommon_histogram::*;
 
 fn increment_u8(c: &mut Criterion) {
     let max = u8::MAX;
 
-    let mut group = c.benchmark_group("Histogram/u8/u8/increment");
+    let mut group = c.benchmark_group("AtomicHistogram/u8/AtomicU8/increment");
 
     for precision in 1..=3 {
-        let mut histogram = Histogram::<u8, u8>::new(max, precision);
+        let histogram = AtomicHistogram::<u8, AtomicU8>::new(max, precision);
         group.throughput(Throughput::Elements(1));
         group.bench_function(BenchmarkId::new("min/precision", precision),
             |b| { b.iter(|| histogram.increment(1, 1)) });
@@ -21,10 +21,10 @@ fn increment_u8(c: &mut Criterion) {
 fn increment_u16(c: &mut Criterion) {
     let max = u16::MAX;
 
-    let mut group = c.benchmark_group("Histogram/u16/u16/increment");
+    let mut group = c.benchmark_group("AtomicHistogram/u16/AtomicU16/increment");
 
     for precision in 1..=5 {
-        let mut histogram = Histogram::<u16, u16>::new(max, precision);
+        let histogram = AtomicHistogram::<u16, AtomicU16>::new(max, precision);
         group.throughput(Throughput::Elements(1));
         group.bench_function(BenchmarkId::new("min/precision", precision),
             |b| { b.iter(|| histogram.increment(1, 1)) });
@@ -36,10 +36,10 @@ fn increment_u16(c: &mut Criterion) {
 fn increment_u32(c: &mut Criterion) {
     let max = u32::MAX;
 
-    let mut group = c.benchmark_group("Histogram/u32/u32/increment");
+    let mut group = c.benchmark_group("AtomicHistogram/u32/AtomicU32/increment");
 
     for precision in 1..=6 {
-        let mut histogram = Histogram::<u32, u32>::new(max, precision);
+        let histogram = AtomicHistogram::<u32, AtomicU32>::new(max, precision);
         group.throughput(Throughput::Elements(1));
         group.bench_function(BenchmarkId::new("min/precision", precision),
             |b| { b.iter(|| histogram.increment(1, 1)) });
@@ -51,10 +51,10 @@ fn increment_u32(c: &mut Criterion) {
 fn increment_u64(c: &mut Criterion) {
     let max = u64::MAX;
 
-    let mut group = c.benchmark_group("Histogram/u64/u64/increment");
+    let mut group = c.benchmark_group("AtomicHistogram/u64/AtomicU64/increment");
 
     for precision in 1..=6 {
-        let mut histogram = Histogram::<u64, u64>::new(max, precision);
+        let histogram = AtomicHistogram::<u64, AtomicU64>::new(max, precision);
         group.throughput(Throughput::Elements(1));
         group.bench_function(BenchmarkId::new("min/precision", precision),
             |b| { b.iter(|| histogram.increment(1, 1)) });
@@ -66,11 +66,11 @@ fn increment_u64(c: &mut Criterion) {
 fn sub_assign_u64(c: &mut Criterion) {
     let max = u64::MAX;
 
-    let mut group = c.benchmark_group("Histogram/u64/u64/sub_assign/fast");
+    let mut group = c.benchmark_group("AtomicHistogram/u64/AtomicU64/sub_assign/fast");
 
     for precision in 1..=6 {
-        let mut alpha = Histogram::<u64, u64>::new(max, precision);
-        let bravo = Histogram::<u64, u64>::new(max, precision);
+        let alpha = AtomicHistogram::<u64, AtomicU64>::new(max, precision);
+        let bravo = AtomicHistogram::<u64, AtomicU64>::new(max, precision);
         group.bench_function(BenchmarkId::new("precision", precision),
             |b| { b.iter(|| alpha.sub_assign(&bravo)) });
     }

--- a/histogram/benches/standard.rs
+++ b/histogram/benches/standard.rs
@@ -1,5 +1,5 @@
-use criterion::Throughput;
 use criterion::BenchmarkId;
+use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rustcommon_histogram::Histogram;
 
@@ -11,10 +11,12 @@ fn increment_u8(c: &mut Criterion) {
     for precision in 1..=3 {
         let mut histogram = Histogram::<u8, u8>::new(max, precision);
         group.throughput(Throughput::Elements(1));
-        group.bench_function(BenchmarkId::new("min/precision", precision),
-            |b| { b.iter(|| histogram.increment(1, 1)) });
-        group.bench_function(BenchmarkId::new("max/precision", precision),
-            |b| { b.iter(|| histogram.increment(max, 1)) });
+        group.bench_function(BenchmarkId::new("min/precision", precision), |b| {
+            b.iter(|| histogram.increment(1, 1))
+        });
+        group.bench_function(BenchmarkId::new("max/precision", precision), |b| {
+            b.iter(|| histogram.increment(max, 1))
+        });
     }
 }
 
@@ -26,10 +28,12 @@ fn increment_u16(c: &mut Criterion) {
     for precision in 1..=5 {
         let mut histogram = Histogram::<u16, u16>::new(max, precision);
         group.throughput(Throughput::Elements(1));
-        group.bench_function(BenchmarkId::new("min/precision", precision),
-            |b| { b.iter(|| histogram.increment(1, 1)) });
-        group.bench_function(BenchmarkId::new("max/precision", precision),
-            |b| { b.iter(|| histogram.increment(max, 1)) });
+        group.bench_function(BenchmarkId::new("min/precision", precision), |b| {
+            b.iter(|| histogram.increment(1, 1))
+        });
+        group.bench_function(BenchmarkId::new("max/precision", precision), |b| {
+            b.iter(|| histogram.increment(max, 1))
+        });
     }
 }
 
@@ -41,10 +45,12 @@ fn increment_u32(c: &mut Criterion) {
     for precision in 1..=6 {
         let mut histogram = Histogram::<u32, u32>::new(max, precision);
         group.throughput(Throughput::Elements(1));
-        group.bench_function(BenchmarkId::new("min/precision", precision),
-            |b| { b.iter(|| histogram.increment(1, 1)) });
-        group.bench_function(BenchmarkId::new("max/precision", precision),
-            |b| { b.iter(|| histogram.increment(max, 1)) });
+        group.bench_function(BenchmarkId::new("min/precision", precision), |b| {
+            b.iter(|| histogram.increment(1, 1))
+        });
+        group.bench_function(BenchmarkId::new("max/precision", precision), |b| {
+            b.iter(|| histogram.increment(max, 1))
+        });
     }
 }
 
@@ -56,10 +62,12 @@ fn increment_u64(c: &mut Criterion) {
     for precision in 1..=6 {
         let mut histogram = Histogram::<u64, u64>::new(max, precision);
         group.throughput(Throughput::Elements(1));
-        group.bench_function(BenchmarkId::new("min/precision", precision),
-            |b| { b.iter(|| histogram.increment(1, 1)) });
-        group.bench_function(BenchmarkId::new("max/precision", precision),
-            |b| { b.iter(|| histogram.increment(max, 1)) });
+        group.bench_function(BenchmarkId::new("min/precision", precision), |b| {
+            b.iter(|| histogram.increment(1, 1))
+        });
+        group.bench_function(BenchmarkId::new("max/precision", precision), |b| {
+            b.iter(|| histogram.increment(max, 1))
+        });
     }
 }
 
@@ -71,8 +79,9 @@ fn sub_assign_u64(c: &mut Criterion) {
     for precision in 1..=6 {
         let mut alpha = Histogram::<u64, u64>::new(max, precision);
         let bravo = Histogram::<u64, u64>::new(max, precision);
-        group.bench_function(BenchmarkId::new("precision", precision),
-            |b| { b.iter(|| alpha.sub_assign(&bravo)) });
+        group.bench_function(BenchmarkId::new("precision", precision), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
     }
 }
 

--- a/histogram/src/histograms/atomic.rs
+++ b/histogram/src/histograms/atomic.rs
@@ -158,10 +158,18 @@ where
         }
     }
 
-    /// Subtract another histogram from this histogram
+    /// Subtracts another histogram from this histogram
     pub fn sub_assign(&self, other: &Self) {
-        for bucket in other {
-            self.decrement(bucket.value, bucket.count);
+        if u64::from(self.max) == u64::from(other.max) && self.precision == other.precision {
+            // fast path when histograms have same configuration
+            for i in 0..self.buckets.len() {
+                self.buckets[i].fetch_saturating_sub(other.buckets[i].load(Ordering::Relaxed), Ordering::Relaxed);
+            }
+        } else {
+            // slow path if we need to calculate appropriate index for each bucket
+            for bucket in other {
+                self.decrement(bucket.value, bucket.count);
+            }
         }
     }
 

--- a/histogram/src/histograms/atomic.rs
+++ b/histogram/src/histograms/atomic.rs
@@ -163,7 +163,10 @@ where
         if u64::from(self.max) == u64::from(other.max) && self.precision == other.precision {
             // fast path when histograms have same configuration
             for i in 0..self.buckets.len() {
-                self.buckets[i].fetch_saturating_sub(other.buckets[i].load(Ordering::Relaxed), Ordering::Relaxed);
+                self.buckets[i].fetch_saturating_sub(
+                    other.buckets[i].load(Ordering::Relaxed),
+                    Ordering::Relaxed,
+                );
             }
         } else {
             // slow path if we need to calculate appropriate index for each bucket

--- a/histogram/src/indexing/u16.rs
+++ b/histogram/src/indexing/u16.rs
@@ -27,9 +27,7 @@ impl crate::Indexing for u16 {
         } else if value <= exact {
             Ok(value.into())
         } else {
-            let power = if value < 10 {
-                0
-            } else if value < 100 {
+            let power = if value < 100 {
                 1
             } else if value < 1_000 {
                 2

--- a/histogram/src/indexing/u32.rs
+++ b/histogram/src/indexing/u32.rs
@@ -27,9 +27,8 @@ impl crate::Indexing for u32 {
         } else if value <= exact {
             Ok(value as usize)
         } else {
-            let power = if value < 10 {
-                0
-            } else if value < 100 {
+            // precision can't be less than 1, so skip < 10 check
+            let power = if value < 100 {
                 1
             } else if value < 1_000 {
                 2
@@ -48,7 +47,6 @@ impl crate::Indexing for u32 {
             } else {
                 9
             };
-            // let power = (value as f64).log10().floor() as u16;
             let denominator = 10_usize.pow((power - precision as u16 + 1).into());
             let power_offset =
                 (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;

--- a/histogram/src/indexing/u64.rs
+++ b/histogram/src/indexing/u64.rs
@@ -27,9 +27,7 @@ impl crate::Indexing for u64 {
         } else if value <= exact {
             Ok(value as usize)
         } else {
-            let power = if value < 10 {
-                0
-            } else if value < 100 {
+            let power = if value < 100 {
                 1
             } else if value < 1_000 {
                 2
@@ -68,7 +66,6 @@ impl crate::Indexing for u64 {
             } else {
                 19
             };
-            // let power = (value as f64).log10().floor() as u16;
             let denominator = 10_usize.pow((power - precision as u16 + 1).into());
             let power_offset =
                 (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;

--- a/histogram/src/indexing/u8.rs
+++ b/histogram/src/indexing/u8.rs
@@ -27,11 +27,7 @@ impl crate::Indexing for u8 {
         } else if value <= exact {
             Ok(value.into())
         } else {
-            let power = if value < 100 {
-                1
-            } else {
-                2
-            };
+            let power = if value < 100 { 1 } else { 2 };
             let denominator = 10_usize.pow((power - precision + 1).into());
             let power_offset =
                 (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;

--- a/histogram/src/indexing/u8.rs
+++ b/histogram/src/indexing/u8.rs
@@ -27,9 +27,7 @@ impl crate::Indexing for u8 {
         } else if value <= exact {
             Ok(value.into())
         } else {
-            let power = if value < 10 {
-                0
-            } else if value < 100 {
+            let power = if value < 100 {
                 1
             } else {
                 2


### PR DESCRIPTION
Applies the same improvement from #35 to AtomicHistogram

Adds benchmarking for AtomicHistogram and improves the benchmarking
for both histogram types.

Removes one comparision for each increment operation across all
indexable types.
