### PR TITLE
heatmap: convert constructor to take a span

### DIFF
--- a/heatmap/src/heatmaps/atomic.rs
+++ b/heatmap/src/heatmaps/atomic.rs
@@ -34,15 +34,19 @@ where
     /// Create a new `AtomicHeatmap` which can store values up and including the
     /// `max` while maintaining precision across a wide range of values. The
     /// `precision` is expressed in the number of significant figures preserved.
-    /// The heatmap will store a histogram for each of the `windows` where each
-    /// window will consist of a duration specified as the `resolution`. The
-    /// combination of the number of windows and resolution places bounds on the
-    /// overall span of time maintained within the heatmap as well as how much
-    /// of the heatmap will be cleared when windows age-out.
-    pub fn new(max: Value, precision: u8, windows: usize, resolution: Duration) -> Self {
+    /// The heatmap will contain a histogram for each time step, specified by
+    /// the resolution, necessary to represent the entire span of time stored
+    /// within the heatmap. If the span is not evenly divisible by the
+    /// resolution an additional window will be allocated and the true span will
+    /// be slightly longer than the requested span. Smaller durations for the
+    /// resolution cause more memory to be used, but a smaller batches of
+    /// samples to age out at each time step.
+    pub fn new(max: Value, precision: u8, span: Duration, resolution: Duration) -> Self {
         let mut slices = Vec::new();
-        for _ in 0..windows {
+        let mut true_span = Duration::new(0, 0);
+        while true_span < span {
             slices.push(AtomicHistogram::new(max, precision));
+            true_span += resolution;
         }
         slices.shrink_to_fit();
         Self {
@@ -145,7 +149,7 @@ mod tests {
 
     #[test]
     fn age_out() {
-        let mut heatmap = Heatmap::<u64, u64>::new(1_000_000, 2, 1000, Duration::from_millis(1));
+        let mut heatmap = Heatmap::<u64, u64>::new(1_000_000, 2, Duration::new(1, 0), Duration::from_millis(1));
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));
@@ -155,7 +159,7 @@ mod tests {
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
 
         let heatmap =
-            AtomicHeatmap::<u64, AtomicU64>::new(1_000_000, 2, 1000, Duration::from_millis(1));
+            AtomicHeatmap::<u64, AtomicU64>::new(1_000_000, 2, Duration::new(1, 0), Duration::from_millis(1));
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));

--- a/heatmap/src/heatmaps/atomic.rs
+++ b/heatmap/src/heatmaps/atomic.rs
@@ -149,7 +149,8 @@ mod tests {
 
     #[test]
     fn age_out() {
-        let mut heatmap = Heatmap::<u64, u64>::new(1_000_000, 2, Duration::new(1, 0), Duration::from_millis(1));
+        let mut heatmap =
+            Heatmap::<u64, u64>::new(1_000_000, 2, Duration::new(1, 0), Duration::from_millis(1));
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));
@@ -158,8 +159,12 @@ mod tests {
         std::thread::sleep(Duration::from_millis(2000));
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
 
-        let heatmap =
-            AtomicHeatmap::<u64, AtomicU64>::new(1_000_000, 2, Duration::new(1, 0), Duration::from_millis(1));
+        let heatmap = AtomicHeatmap::<u64, AtomicU64>::new(
+            1_000_000,
+            2,
+            Duration::new(1, 0),
+            Duration::from_millis(1),
+        );
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));

--- a/heatmap/src/lib.rs
+++ b/heatmap/src/lib.rs
@@ -21,7 +21,7 @@ mod tests {
 
     #[test]
     fn age_out() {
-        let mut heatmap = Heatmap::<u64, u64>::new(1_000_000, 2, 1000, Duration::from_millis(1));
+        let mut heatmap = Heatmap::<u64, u64>::new(1_000_000, 2, Duration::new(1, 0), Duration::from_millis(1));
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));
@@ -31,7 +31,7 @@ mod tests {
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
 
         let heatmap =
-            AtomicHeatmap::<u64, AtomicU64>::new(1_000_000, 2, 1000, Duration::from_millis(1));
+            AtomicHeatmap::<u64, AtomicU64>::new(1_000_000, 2, Duration::new(1, 0), Duration::from_millis(1));
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));

--- a/heatmap/src/lib.rs
+++ b/heatmap/src/lib.rs
@@ -21,7 +21,8 @@ mod tests {
 
     #[test]
     fn age_out() {
-        let mut heatmap = Heatmap::<u64, u64>::new(1_000_000, 2, Duration::new(1, 0), Duration::from_millis(1));
+        let mut heatmap =
+            Heatmap::<u64, u64>::new(1_000_000, 2, Duration::new(1, 0), Duration::from_millis(1));
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));
@@ -30,8 +31,12 @@ mod tests {
         std::thread::sleep(Duration::from_millis(2000));
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
 
-        let heatmap =
-            AtomicHeatmap::<u64, AtomicU64>::new(1_000_000, 2, Duration::new(1, 0), Duration::from_millis(1));
+        let heatmap = AtomicHeatmap::<u64, AtomicU64>::new(
+            1_000_000,
+            2,
+            Duration::new(1, 0),
+            Duration::from_millis(1),
+        );
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));

--- a/metrics/src/summary/mod.rs
+++ b/metrics/src/summary/mod.rs
@@ -62,10 +62,10 @@ where
     pub fn heatmap(
         max: <Value as Atomic>::Primitive,
         precision: u8,
-        windows: usize,
+        span: Duration,
         resolution: Duration,
     ) -> Self {
-        Self::Heatmap(AtomicHeatmap::new(max, precision, windows, resolution))
+        Self::Heatmap(AtomicHeatmap::new(max, precision, span, resolution))
     }
 
     pub fn stream(samples: usize) -> Self {
@@ -79,7 +79,7 @@ where
     <Value as Atomic>::Primitive: Primitive,
     u64: From<<Value as Atomic>::Primitive>,
 {
-    Heatmap(<Value as Atomic>::Primitive, u8, usize, Duration),
+    Heatmap(<Value as Atomic>::Primitive, u8, Duration, Duration),
     Stream(usize),
 }
 
@@ -106,11 +106,11 @@ where
     pub fn heatmap(
         max: <Value as Atomic>::Primitive,
         precision: u8,
-        windows: usize,
+        span: Duration,
         resolution: Duration,
     ) -> Summary<Value, Count> {
         Self {
-            inner: SummaryType::Heatmap(max, precision, windows, resolution),
+            inner: SummaryType::Heatmap(max, precision, span, resolution),
             _count: PhantomData,
         }
     }
@@ -124,8 +124,8 @@ where
 
     pub(crate) fn build(&self) -> SummaryStruct<Value, Count> {
         match self.inner {
-            SummaryType::Heatmap(max, precision, windows, resolution) => {
-                SummaryStruct::heatmap(max, precision, windows, resolution)
+            SummaryType::Heatmap(max, precision, span, resolution) => {
+                SummaryStruct::heatmap(max, precision, span, resolution)
             }
             SummaryType::Stream(samples) => SummaryStruct::stream(samples),
         }

--- a/waterfall/examples/simulator.rs
+++ b/waterfall/examples/simulator.rs
@@ -40,10 +40,10 @@ pub enum Shape {
 
 pub fn simulate(shape: Shape) {
     info!("Simulating for {:?} distribution", shape);
-    let duration = 120;
+    let duration = Duration::new(120, 0);
 
     let mut heatmap =
-        rustcommon_heatmap::Heatmap::<u64, u64>::new(1_000_000, 3, 120, Duration::new(1, 0));
+        rustcommon_heatmap::Heatmap::<u64, u64>::new(1_000_000, 3, duration, Duration::new(1, 0));
 
     let cauchy = Cauchy::new(500_000.0, 2_000.00).unwrap();
     let normal = Normal::new(200_000.0, 100_000.0).unwrap();
@@ -51,12 +51,10 @@ pub fn simulate(shape: Shape) {
     let triangular = Triangular::new(1.0, 200_000.0, 50_000.0).unwrap();
     let gamma = Gamma::new(2.0, 2.0).unwrap();
 
-    let start = std::time::Instant::now();
     let mut rng = thread_rng();
-
+    let start = std::time::Instant::now();
     loop {
-        let now = std::time::Instant::now();
-        if now - start >= std::time::Duration::new(duration, 0) {
+        if start.elapsed() >= duration {
             break;
         }
         let value: f64 = match shape {


### PR DESCRIPTION
Changes the API of the heatmap constructor to take a 'span' of time
instead of the number of 'windows' to hold. This can allow for
easier usage particularly if resoltion is parameterized but a fixed
span of time should be represented.
