### PR TITLE
histogram: improvements to sub_assign() perf for slow path

### DIFF
--- a/histogram/benches/atomic.rs
+++ b/histogram/benches/atomic.rs
@@ -137,7 +137,6 @@ fn sub_assign_u32(c: &mut Criterion) {
     }
 }
 
-
 fn sub_assign_u64(c: &mut Criterion) {
     let max = u64::MAX;
 

--- a/histogram/benches/atomic.rs
+++ b/histogram/benches/atomic.rs
@@ -42,7 +42,7 @@ fn increment_u32(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("AtomicHistogram/u32/AtomicU32/increment");
 
-    for precision in 1..=6 {
+    for precision in 1..=7 {
         let histogram = AtomicHistogram::<u32, AtomicU32>::new(max, precision);
         group.throughput(Throughput::Elements(1));
         group.bench_function(BenchmarkId::new("min/precision", precision), |b| {
@@ -71,15 +71,90 @@ fn increment_u64(c: &mut Criterion) {
     }
 }
 
+fn sub_assign_u8(c: &mut Criterion) {
+    let max = u8::MAX;
+
+    let mut group = c.benchmark_group("AtomicHistogram/u8/AtomicU8/sub_assign");
+
+    for precision in 1..=3 {
+        let alpha = AtomicHistogram::<u8, AtomicU8>::new(max, precision);
+        let bravo = AtomicHistogram::<u8, AtomicU8>::new(max, precision);
+        group.bench_function(BenchmarkId::new("fast/precision", precision), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+
+    for precision in 1..3 {
+        let alpha = AtomicHistogram::<u8, AtomicU8>::new(max, precision + 1);
+        let bravo = AtomicHistogram::<u8, AtomicU8>::new(max, precision);
+        group.bench_function(BenchmarkId::new("slow/precision", precision + 1), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+}
+
+fn sub_assign_u16(c: &mut Criterion) {
+    let max = u16::MAX;
+
+    let mut group = c.benchmark_group("AtomicHistogram/u16/AtomicU16/sub_assign");
+
+    for precision in 1..=4 {
+        let alpha = AtomicHistogram::<u16, AtomicU16>::new(max, precision);
+        let bravo = AtomicHistogram::<u16, AtomicU16>::new(max, precision);
+        group.bench_function(BenchmarkId::new("fast/precision", precision), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+
+    for precision in 1..4 {
+        let alpha = AtomicHistogram::<u16, AtomicU16>::new(max, precision + 1);
+        let bravo = AtomicHistogram::<u16, AtomicU16>::new(max, precision);
+        group.bench_function(BenchmarkId::new("slow/precision", precision + 1), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+}
+
+fn sub_assign_u32(c: &mut Criterion) {
+    let max = u32::MAX;
+
+    let mut group = c.benchmark_group("AtomicHistogram/u32/AtomicU32/sub_assign");
+
+    for precision in 1..=7 {
+        let alpha = AtomicHistogram::<u32, AtomicU32>::new(max, precision);
+        let bravo = AtomicHistogram::<u32, AtomicU32>::new(max, precision);
+        group.bench_function(BenchmarkId::new("fast/precision", precision), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+
+    for precision in 1..7 {
+        let alpha = AtomicHistogram::<u32, AtomicU32>::new(max, precision + 1);
+        let bravo = AtomicHistogram::<u32, AtomicU32>::new(max, precision);
+        group.bench_function(BenchmarkId::new("slow/precision", precision + 1), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+}
+
+
 fn sub_assign_u64(c: &mut Criterion) {
     let max = u64::MAX;
 
-    let mut group = c.benchmark_group("AtomicHistogram/u64/AtomicU64/sub_assign/fast");
+    let mut group = c.benchmark_group("AtomicHistogram/u64/AtomicU64/sub_assign");
 
     for precision in 1..=6 {
         let alpha = AtomicHistogram::<u64, AtomicU64>::new(max, precision);
         let bravo = AtomicHistogram::<u64, AtomicU64>::new(max, precision);
-        group.bench_function(BenchmarkId::new("precision", precision), |b| {
+        group.bench_function(BenchmarkId::new("fast/precision", precision), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+
+    for precision in 1..6 {
+        let alpha = AtomicHistogram::<u64, AtomicU64>::new(max, precision + 1);
+        let bravo = AtomicHistogram::<u64, AtomicU64>::new(max, precision);
+        group.bench_function(BenchmarkId::new("slow/precision", precision + 1), |b| {
             b.iter(|| alpha.sub_assign(&bravo))
         });
     }
@@ -91,6 +166,9 @@ criterion_group!(
     increment_u16,
     increment_u32,
     increment_u64,
+    sub_assign_u8,
+    sub_assign_u16,
+    sub_assign_u32,
     sub_assign_u64,
 );
 criterion_main!(benches);

--- a/histogram/benches/standard.rs
+++ b/histogram/benches/standard.rs
@@ -137,7 +137,6 @@ fn sub_assign_u32(c: &mut Criterion) {
     }
 }
 
-
 fn sub_assign_u64(c: &mut Criterion) {
     let max = u64::MAX;
 

--- a/histogram/benches/standard.rs
+++ b/histogram/benches/standard.rs
@@ -71,15 +71,90 @@ fn increment_u64(c: &mut Criterion) {
     }
 }
 
+fn sub_assign_u8(c: &mut Criterion) {
+    let max = u8::MAX;
+
+    let mut group = c.benchmark_group("Histogram/u8/u8/sub_assign");
+
+    for precision in 1..=3 {
+        let mut alpha = Histogram::<u8, u8>::new(max, precision);
+        let bravo = Histogram::<u8, u8>::new(max, precision);
+        group.bench_function(BenchmarkId::new("fast/precision", precision), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+
+    for precision in 1..3 {
+        let mut alpha = Histogram::<u8, u8>::new(max, precision + 1);
+        let bravo = Histogram::<u8, u8>::new(max, precision);
+        group.bench_function(BenchmarkId::new("slow/precision", precision + 1), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+}
+
+fn sub_assign_u16(c: &mut Criterion) {
+    let max = u16::MAX;
+
+    let mut group = c.benchmark_group("Histogram/u16/u16/sub_assign");
+
+    for precision in 1..=4 {
+        let mut alpha = Histogram::<u16, u16>::new(max, precision);
+        let bravo = Histogram::<u16, u16>::new(max, precision);
+        group.bench_function(BenchmarkId::new("fast/precision", precision), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+
+    for precision in 1..4 {
+        let mut alpha = Histogram::<u16, u16>::new(max, precision + 1);
+        let bravo = Histogram::<u16, u16>::new(max, precision);
+        group.bench_function(BenchmarkId::new("slow/precision", precision + 1), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+}
+
+fn sub_assign_u32(c: &mut Criterion) {
+    let max = u32::MAX;
+
+    let mut group = c.benchmark_group("Histogram/u32/u32/sub_assign");
+
+    for precision in 1..=7 {
+        let mut alpha = Histogram::<u32, u32>::new(max, precision);
+        let bravo = Histogram::<u32, u32>::new(max, precision);
+        group.bench_function(BenchmarkId::new("fast/precision", precision), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+
+    for precision in 1..7 {
+        let mut alpha = Histogram::<u32, u32>::new(max, precision + 1);
+        let bravo = Histogram::<u32, u32>::new(max, precision);
+        group.bench_function(BenchmarkId::new("slow/precision", precision + 1), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+}
+
+
 fn sub_assign_u64(c: &mut Criterion) {
     let max = u64::MAX;
 
-    let mut group = c.benchmark_group("Histogram/u64/u64/sub_assign/fast");
+    let mut group = c.benchmark_group("Histogram/u64/u64/sub_assign");
 
     for precision in 1..=6 {
         let mut alpha = Histogram::<u64, u64>::new(max, precision);
         let bravo = Histogram::<u64, u64>::new(max, precision);
-        group.bench_function(BenchmarkId::new("precision", precision), |b| {
+        group.bench_function(BenchmarkId::new("fast/precision", precision), |b| {
+            b.iter(|| alpha.sub_assign(&bravo))
+        });
+    }
+
+    for precision in 1..6 {
+        let mut alpha = Histogram::<u64, u64>::new(max, precision + 1);
+        let bravo = Histogram::<u64, u64>::new(max, precision);
+        group.bench_function(BenchmarkId::new("slow/precision", precision + 1), |b| {
             b.iter(|| alpha.sub_assign(&bravo))
         });
     }
@@ -91,6 +166,9 @@ criterion_group!(
     increment_u16,
     increment_u32,
     increment_u64,
+    sub_assign_u8,
+    sub_assign_u16,
+    sub_assign_u32,
     sub_assign_u64,
 );
 criterion_main!(benches);

--- a/histogram/src/indexing/u16.rs
+++ b/histogram/src/indexing/u16.rs
@@ -37,8 +37,7 @@ impl crate::Indexing for u16 {
                 4
             };
             let denominator = 10_usize.pow((power - precision as u16 + 1).into());
-            let power_offset =
-                9 * exact as usize * (power as usize - precision as usize) / 10;
+            let power_offset = 9 * exact as usize * (power as usize - precision as usize) / 10;
             let remainder: usize = value as usize / denominator;
             let shift = exact as usize / 10;
             let index = exact as usize + power_offset + remainder - shift;

--- a/histogram/src/indexing/u16.rs
+++ b/histogram/src/indexing/u16.rs
@@ -38,7 +38,7 @@ impl crate::Indexing for u16 {
             };
             let denominator = 10_usize.pow((power - precision as u16 + 1).into());
             let power_offset =
-                (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;
+                9 * exact as usize * (power as usize - precision as usize) / 10;
             let remainder: usize = value as usize / denominator;
             let shift = exact as usize / 10;
             let index = exact as usize + power_offset + remainder - shift;
@@ -64,7 +64,7 @@ impl crate::Indexing for u16 {
             let base_offset = 10_usize.pow(precision.into());
             let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
-            let power_offset = (0.9 * (base_offset * (power - precision as usize)) as f64) as usize;
+            let power_offset = 9 * (shift * (power - precision as usize));
             let value = (index + shift - base_offset - power_offset) as u16
                 * 10_u16.pow((power - precision as usize + 1) as u32);
             Ok(value)

--- a/histogram/src/indexing/u16.rs
+++ b/histogram/src/indexing/u16.rs
@@ -64,9 +64,7 @@ impl crate::Indexing for u16 {
             let base_offset = 10_usize.pow(precision.into());
             let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
-            let power_offset = (0.9
-                * (base_offset * (power - precision as usize)) as f64)
-                as usize;
+            let power_offset = (0.9 * (base_offset * (power - precision as usize)) as f64) as usize;
             let value = (index + shift - base_offset - power_offset) as u16
                 * 10_u16.pow((power - precision as usize + 1) as u32);
             Ok(value)

--- a/histogram/src/indexing/u16.rs
+++ b/histogram/src/indexing/u16.rs
@@ -61,11 +61,11 @@ impl crate::Indexing for u16 {
         } else if index == buckets - 1 {
             Ok(max)
         } else {
-            let shift = 10_usize.pow((precision - 1).into());
             let base_offset = 10_usize.pow(precision.into());
+            let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
             let power_offset = (0.9
-                * (10_usize.pow(precision.into()) * (power - precision as usize)) as f64)
+                * (base_offset * (power - precision as usize)) as f64)
                 as usize;
             let value = (index + shift - base_offset - power_offset) as u16
                 * 10_u16.pow((power - precision as usize + 1) as u32);

--- a/histogram/src/indexing/u32.rs
+++ b/histogram/src/indexing/u32.rs
@@ -48,8 +48,7 @@ impl crate::Indexing for u32 {
                 9
             };
             let denominator = 10_usize.pow((power - precision as u16 + 1).into());
-            let power_offset =
-                9 * exact as usize * (power as usize - precision as usize) / 10;
+            let power_offset = 9 * exact as usize * (power as usize - precision as usize) / 10;
             let remainder: usize = value as usize / denominator;
             let shift = exact as usize / 10;
             let index = exact as usize + power_offset + remainder - shift;

--- a/histogram/src/indexing/u32.rs
+++ b/histogram/src/indexing/u32.rs
@@ -72,11 +72,11 @@ impl crate::Indexing for u32 {
         } else if index == buckets - 1 {
             Ok(max)
         } else {
-            let shift = 10_usize.pow((precision - 1).into());
             let base_offset = 10_usize.pow(precision.into());
+            let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
             let power_offset = (0.9
-                * (10_usize.pow(precision.into()) * (power - precision as usize)) as f64)
+                * (base_offset * (power - precision as usize)) as f64)
                 as usize;
             let value = (index + shift - base_offset - power_offset) as u32
                 * 10_u32.pow((power - precision as usize + 1) as u32);

--- a/histogram/src/indexing/u32.rs
+++ b/histogram/src/indexing/u32.rs
@@ -75,9 +75,7 @@ impl crate::Indexing for u32 {
             let base_offset = 10_usize.pow(precision.into());
             let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
-            let power_offset = (0.9
-                * (base_offset * (power - precision as usize)) as f64)
-                as usize;
+            let power_offset = (0.9 * (base_offset * (power - precision as usize)) as f64) as usize;
             let value = (index + shift - base_offset - power_offset) as u32
                 * 10_u32.pow((power - precision as usize + 1) as u32);
             Ok(value)

--- a/histogram/src/indexing/u32.rs
+++ b/histogram/src/indexing/u32.rs
@@ -49,7 +49,7 @@ impl crate::Indexing for u32 {
             };
             let denominator = 10_usize.pow((power - precision as u16 + 1).into());
             let power_offset =
-                (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;
+                9 * exact as usize * (power as usize - precision as usize) / 10;
             let remainder: usize = value as usize / denominator;
             let shift = exact as usize / 10;
             let index = exact as usize + power_offset + remainder - shift;
@@ -75,7 +75,7 @@ impl crate::Indexing for u32 {
             let base_offset = 10_usize.pow(precision.into());
             let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
-            let power_offset = (0.9 * (base_offset * (power - precision as usize)) as f64) as usize;
+            let power_offset = 9 * (shift * (power - precision as usize));
             let value = (index + shift - base_offset - power_offset) as u32
                 * 10_u32.pow((power - precision as usize + 1) as u32);
             Ok(value)

--- a/histogram/src/indexing/u64.rs
+++ b/histogram/src/indexing/u64.rs
@@ -66,9 +66,9 @@ impl crate::Indexing for u64 {
             } else {
                 19
             };
-            let denominator = 10_usize.pow((power - precision as u16 + 1).into());
+            let denominator = 10_usize.pow((power - precision as u32 + 1).into());
             let power_offset =
-                (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;
+                (0.9_f64 * f64::from(exact as u32 * (power - precision as u32))) as usize;
             let remainder: usize = value as usize / denominator;
             let shift = exact as usize / 10;
             let index = exact as usize + power_offset + remainder - shift;
@@ -91,11 +91,11 @@ impl crate::Indexing for u64 {
         } else if index == buckets - 1 {
             Ok(max)
         } else {
-            let shift = 10_usize.pow((precision - 1).into());
             let base_offset = 10_usize.pow(precision.into());
+            let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
             let power_offset = (0.9
-                * (10_usize.pow(precision.into()) * (power - precision as usize)) as f64)
+                * (base_offset * (power - precision as usize)) as f64)
                 as usize;
             let value = (index + shift - base_offset - power_offset) as u64
                 * 10_u64.pow((power - precision as usize + 1) as u32);

--- a/histogram/src/indexing/u64.rs
+++ b/histogram/src/indexing/u64.rs
@@ -94,9 +94,7 @@ impl crate::Indexing for u64 {
             let base_offset = 10_usize.pow(precision.into());
             let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
-            let power_offset = (0.9
-                * (base_offset * (power - precision as usize)) as f64)
-                as usize;
+            let power_offset = (0.9 * (base_offset * (power - precision as usize)) as f64) as usize;
             let value = (index + shift - base_offset - power_offset) as u64
                 * 10_u64.pow((power - precision as usize + 1) as u32);
             Ok(value)

--- a/histogram/src/indexing/u64.rs
+++ b/histogram/src/indexing/u64.rs
@@ -68,7 +68,7 @@ impl crate::Indexing for u64 {
             };
             let denominator = 10_usize.pow((power - precision as u32 + 1).into());
             let power_offset =
-                (0.9_f64 * f64::from(exact as u32 * (power - precision as u32))) as usize;
+                9 * exact as usize * (power as usize - precision as usize) / 10;
             let remainder: usize = value as usize / denominator;
             let shift = exact as usize / 10;
             let index = exact as usize + power_offset + remainder - shift;
@@ -94,7 +94,7 @@ impl crate::Indexing for u64 {
             let base_offset = 10_usize.pow(precision.into());
             let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
-            let power_offset = (0.9 * (base_offset * (power - precision as usize)) as f64) as usize;
+            let power_offset = 9 * (shift * (power - precision as usize));
             let value = (index + shift - base_offset - power_offset) as u64
                 * 10_u64.pow((power - precision as usize + 1) as u32);
             Ok(value)

--- a/histogram/src/indexing/u64.rs
+++ b/histogram/src/indexing/u64.rs
@@ -67,8 +67,7 @@ impl crate::Indexing for u64 {
                 19
             };
             let denominator = 10_usize.pow((power - precision as u32 + 1).into());
-            let power_offset =
-                9 * exact as usize * (power as usize - precision as usize) / 10;
+            let power_offset = 9 * exact as usize * (power as usize - precision as usize) / 10;
             let remainder: usize = value as usize / denominator;
             let shift = exact as usize / 10;
             let index = exact as usize + power_offset + remainder - shift;

--- a/histogram/src/indexing/u8.rs
+++ b/histogram/src/indexing/u8.rs
@@ -56,9 +56,7 @@ impl crate::Indexing for u8 {
             let base_offset = 10_usize.pow(precision.into());
             let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
-            let power_offset = (0.9
-                * (base_offset * (power - precision as usize)) as f64)
-                as usize;
+            let power_offset = (0.9 * (base_offset * (power - precision as usize)) as f64) as usize;
             let value = (index + shift - base_offset - power_offset) as u8
                 * 10_u8.pow((power - precision as usize + 1) as u32);
             Ok(value)

--- a/histogram/src/indexing/u8.rs
+++ b/histogram/src/indexing/u8.rs
@@ -30,7 +30,7 @@ impl crate::Indexing for u8 {
             let power = if value < 100 { 1 } else { 2 };
             let denominator = 10_usize.pow((power - precision + 1).into());
             let power_offset =
-                (0.9_f64 * f64::from(exact as u32 * (power as u32 - precision as u32))) as usize;
+                9 * exact as usize * (power as usize - precision as usize) / 10;
             let remainder: usize = value as usize / denominator;
             let shift = exact as usize / 10;
             let index = exact as usize + power_offset + remainder - shift;
@@ -56,7 +56,7 @@ impl crate::Indexing for u8 {
             let base_offset = 10_usize.pow(precision.into());
             let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
-            let power_offset = (0.9 * (base_offset * (power - precision as usize)) as f64) as usize;
+            let power_offset = 9 * (shift * (power - precision as usize));
             let value = (index + shift - base_offset - power_offset) as u8
                 * 10_u8.pow((power - precision as usize + 1) as u32);
             Ok(value)

--- a/histogram/src/indexing/u8.rs
+++ b/histogram/src/indexing/u8.rs
@@ -53,11 +53,11 @@ impl crate::Indexing for u8 {
         } else if index == buckets - 1 {
             Ok(max)
         } else {
-            let shift = 10_usize.pow((precision - 1).into());
             let base_offset = 10_usize.pow(precision.into());
+            let shift = base_offset / 10;
             let power = precision as usize + (index - base_offset) / (9 * shift);
             let power_offset = (0.9
-                * (10_usize.pow(precision.into()) * (power - precision as usize)) as f64)
+                * (base_offset * (power - precision as usize)) as f64)
                 as usize;
             let value = (index + shift - base_offset - power_offset) as u8
                 * 10_u8.pow((power - precision as usize + 1) as u32);

--- a/histogram/src/indexing/u8.rs
+++ b/histogram/src/indexing/u8.rs
@@ -29,8 +29,7 @@ impl crate::Indexing for u8 {
         } else {
             let power = if value < 100 { 1 } else { 2 };
             let denominator = 10_usize.pow((power - precision + 1).into());
-            let power_offset =
-                9 * exact as usize * (power as usize - precision as usize) / 10;
+            let power_offset = 9 * exact as usize * (power as usize - precision as usize) / 10;
             let remainder: usize = value as usize / denominator;
             let shift = exact as usize / 10;
             let index = exact as usize + power_offset + remainder - shift;


### PR DESCRIPTION
There's a slowpath for sub_assign() when two histograms have
different configuration. This is probably less likely to get hit,
but the optimizations apply to iterator performance too.

Some optimizations in calculating the value for a bucket index
yields about 30% improvement on sub_assign() slow path.
