### PR TITLE
metrics: performance improvements

### DIFF
--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -10,3 +10,10 @@ rustcommon-atomics = { path = "../atomics" }
 rustcommon-heatmap = { path = "../heatmap" }
 rustcommon-streamstats = { path = "../streamstats" }
 thiserror = "1.0.20"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "counters"
+harness = false

--- a/metrics/benches/counters.rs
+++ b/metrics/benches/counters.rs
@@ -1,0 +1,60 @@
+use std::time::Instant;
+use std::sync::Arc;
+use criterion::Throughput;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rustcommon_metrics::*;
+
+enum StatU8 {
+    Alpha,
+    Bravo,
+}
+
+impl Statistic<AtomicU8, AtomicU8> for StatU8 {
+    fn name(&self) -> &str {
+        match self {
+            StatU8::Alpha => "alpha",
+            StatU8::Bravo => "bravo",
+        }
+    }
+
+    fn source(&self) -> Source {
+        match self {
+            StatU8::Alpha => Source::Counter,
+            StatU8::Bravo => Source::Counter,
+        }
+    }
+
+    fn summary(&self) -> Option<Summary<AtomicU8, AtomicU8>> {
+        match self {
+            StatU8::Bravo => Some(Summary::stream(1000)),
+            _ => None,
+        }
+    }
+}
+
+fn u8_u8(c: &mut Criterion) {
+    let metrics = Arc::new(Metrics::<AtomicU8, AtomicU8>::new());
+
+    metrics.register(&StatU8::Alpha);
+    metrics.add_output(&StatU8::Alpha, Output::Reading);
+
+    metrics.register(&StatU8::Bravo);
+    metrics.add_output(&StatU8::Bravo, Output::Reading);
+
+    let mut group = c.benchmark_group("Metrics/AtomicU8/AtomicU8/counter");
+
+    group.throughput(Throughput::Elements(1));
+    let now = Instant::now();
+    group.bench_function("no_summary/record", |b| {
+        b.iter(|| metrics.record_counter(&StatU8::Alpha, now, 255))
+    });
+    group.bench_function("stream/1000/record", |b| {
+        b.iter(|| metrics.record_counter(&StatU8::Bravo, now, 255))
+    });
+}
+
+criterion_group!(
+    benches,
+    u8_u8,
+);
+criterion_main!(benches);

--- a/metrics/src/channel/mod.rs
+++ b/metrics/src/channel/mod.rs
@@ -2,6 +2,11 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use crate::Output;
+use std::sync::Mutex;
+use std::collections::HashSet;
+use crate::outputs::ApproxOutput;
+use crate::entry::Entry;
 use crate::summary::SummaryStruct;
 use crate::traits::*;
 use crate::MetricsError;
@@ -23,9 +28,11 @@ where
     u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
     refreshed: RwLock<Instant>,
+    statistic: Entry<Value, Count>,
     empty: AtomicBool,
     reading: Value,
     summary: Option<SummaryStruct<Value, Count>>,
+    outputs: Mutex<HashSet<ApproxOutput>>,
 }
 
 impl<Value, Count> Channel<Value, Count>
@@ -41,9 +48,11 @@ where
         let summary = statistic.summary().map(|v| v.build());
         Self {
             empty: AtomicBool::new(true),
+            statistic: Entry::from(statistic),
             reading: Default::default(),
             refreshed: RwLock::new(Instant::now()),
             summary,
+            outputs: Default::default(),
         }
     }
 
@@ -153,5 +162,28 @@ where
         if self.summary.is_none() {
             self.set_summary(summary);
         }
+    }
+
+    pub fn statistic(&self) -> &dyn Statistic<Value, Count> {
+        &self.statistic
+    }
+
+    pub fn outputs(&self) -> Vec<ApproxOutput> {
+        let mut ret = Vec::new();
+        let outputs = self.outputs.lock().unwrap();
+        for output in (*outputs).iter().map(|v| v.clone()) {
+            ret.push(output);
+        }
+        ret
+    }
+
+    pub fn add_output(&self, output: Output) {
+        let mut outputs = self.outputs.lock().unwrap();
+        (*outputs).insert(ApproxOutput::from(output));
+    }
+
+    pub fn remove_output(&self, output: Output) {
+        let mut outputs = self.outputs.lock().unwrap();
+        (*outputs).remove(&ApproxOutput::from(output));
     }
 }

--- a/metrics/src/entry/mod.rs
+++ b/metrics/src/entry/mod.rs
@@ -10,7 +10,6 @@ use crate::*;
 
 use rustcommon_atomics::Atomic;
 
-#[derive(Clone)]
 pub struct Entry<Value, Count>
 where
     Value: crate::Value,
@@ -23,6 +22,24 @@ where
     source: Source,
     _value: PhantomData<Value>,
     _count: PhantomData<Count>,
+}
+
+impl<Value, Count> Clone for Entry<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            source: self.source.clone(),
+            _value: self._value.clone(),
+            _count: self._count.clone(),
+        }
+    }
 }
 
 impl<Value, Count> Statistic<Value, Count> for Entry<Value, Count>

--- a/metrics/src/metrics/mod.rs
+++ b/metrics/src/metrics/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::channel::Channel;
 use crate::entry::Entry;
-use crate::outputs::{ApproxOutput, Outputs};
+use crate::outputs::ApproxOutput;
 use crate::*;
 use core::hash::Hash;
 use core::hash::Hasher;
@@ -28,11 +28,11 @@ where
     <Count as Atomic>::Primitive: Primitive,
     u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
-    channels: DashMap<Entry<Value, Count>, Channel<Value, Count>>,
-    outputs: Outputs<Value, Count>,
+    channels: DashMap<String, Channel<Value, Count>>,
+    // outputs: Outputs<Value, Count>,
 }
 
-impl<Value, Count> Metrics<Value, Count>
+impl<'a, Value: 'a, Count: 'a> Metrics<Value, Count>
 where
     Value: crate::Value,
     Count: crate::Count,
@@ -44,33 +44,33 @@ where
     pub fn new() -> Self {
         Self {
             channels: DashMap::new(),
-            outputs: Outputs::new(),
         }
     }
 
     /// Begin tracking a new statistic without a corresponding output. Useful if
     /// metrics will be retrieved and reported manually in a command-line tool.
-    pub fn register(&self, statistic: &dyn Statistic<Value, Count>) {
-        let entry = Entry::from(statistic);
-        if !self.channels.contains_key(&entry) {
+    pub fn register(&self, statistic: &'a (dyn Statistic<Value, Count> + 'a)) {
+        if !self.channels.contains_key(statistic.name()) {
             let channel = Channel::new(statistic);
-            self.channels.insert(entry, channel);
+            self.channels.insert(statistic.name().to_string(), channel);
         }
     }
 
     /// Stop tracking a statistics and any corresponding outputs.
-    pub fn deregister(&self, statistic: &dyn Statistic<Value, Count>) {
-        let entry = Entry::from(statistic);
-        self.outputs.deregister_statistic(statistic);
-        self.channels.remove(&entry);
+    pub fn deregister(&self, statistic: &'a (dyn Statistic<Value, Count> + 'a)) {
+        // self.outputs.deregister_statistic(statistic);
+        self.channels.remove(statistic.name());
     }
 
     /// Adds a new output to the registry which will be included in future
     /// snapshots. If the statistic is not already tracked, it will be
     /// registered.
-    pub fn add_output(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
+    pub fn add_output(&self, statistic: &'a (dyn Statistic<Value, Count> + 'a), output: Output) {
         self.register(statistic);
-        self.outputs.register(statistic, output);
+        if let Some(channel) = self.channels.get_mut(statistic.name()) {
+        	channel.add_output(output);
+        }
+        // self.outputs.register(statistic, output);
     }
 
     /// Remove an output from the registry so that it will not be included in
@@ -78,7 +78,10 @@ where
     /// the statistic even if no outputs remain. Use `deregister` method to stop
     /// tracking a statistic entirely.
     pub fn remove_output(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
-        self.outputs.deregister(statistic, output);
+    	if let Some(channel) = self.channels.get_mut(statistic.name()) {
+    		channel.remove_output(output);
+    	}
+        // self.outputs.deregister(statistic, output);
     }
 
     /// Set the `Summary` for an already registered `Statistic`. This can be
@@ -87,11 +90,10 @@ where
     /// may need to be higher for stream summaries.
     pub fn set_summary(
         &self,
-        statistic: &dyn Statistic<Value, Count>,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
         summary: Summary<Value, Count>,
     ) {
-        let entry = Entry::from(statistic);
-        if let Some(mut channel) = self.channels.get_mut(&entry) {
+        if let Some(mut channel) = self.channels.get_mut(statistic.name()) {
             channel.set_summary(summary);
         }
     }
@@ -101,18 +103,17 @@ where
     /// prevent clearing an existing summary.
     pub fn add_summary(
         &self,
-        statistic: &dyn Statistic<Value, Count>,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
         summary: Summary<Value, Count>,
     ) {
-        let entry = Entry::from(statistic);
-        if let Some(mut channel) = self.channels.get_mut(&entry) {
+        if let Some(mut channel) = self.channels.get_mut(statistic.name()) {
             channel.add_summary(summary);
         }
     }
 
     /// Remove all statistics and outputs.
     pub fn clear(&self) {
-        self.outputs.clear();
+        // self.outputs.clear();
         self.channels.clear();
     }
 
@@ -121,14 +122,13 @@ where
     /// for the statistic is a heatmap.
     pub fn record_bucket(
         &self,
-        statistic: &dyn Statistic<Value, Count>,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
         time: Instant,
         value: <Value as Atomic>::Primitive,
         count: <Count as Atomic>::Primitive,
     ) -> Result<(), MetricsError> {
-        let entry = Entry::from(statistic);
         if statistic.source() == Source::Distribution {
-            if let Some(channel) = self.channels.get(&entry) {
+            if let Some(channel) = self.channels.get(statistic.name()) {
                 channel.record_bucket(time, value, count)
             } else {
                 // statistic not registered
@@ -145,13 +145,12 @@ where
     /// changes.
     pub fn record_counter(
         &self,
-        statistic: &dyn Statistic<Value, Count>,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
         time: Instant,
         value: <Value as Atomic>::Primitive,
     ) -> Result<(), MetricsError> {
-        let entry = Entry::from(statistic);
         if statistic.source() == Source::Counter {
-            if let Some(channel) = self.channels.get(&entry) {
+            if let Some(channel) = self.channels.get(statistic.name()) {
                 channel.record_counter(time, value);
                 Ok(())
             } else {
@@ -169,12 +168,11 @@ where
     /// with out-of-order increments.
     pub fn increment_counter(
         &self,
-        statistic: &dyn Statistic<Value, Count>,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
         value: <Value as Atomic>::Primitive,
     ) -> Result<(), MetricsError> {
-        let entry = Entry::from(statistic);
         if statistic.source() == Source::Counter {
-            if let Some(channel) = self.channels.get(&entry) {
+            if let Some(channel) = self.channels.get(statistic.name()) {
                 channel.increment_counter(value);
                 Ok(())
             } else {
@@ -191,13 +189,12 @@ where
     /// any summary type. Summary tracks instantaneous gauge readings.
     pub fn record_gauge(
         &self,
-        statistic: &dyn Statistic<Value, Count>,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
         time: Instant,
         value: <Value as Atomic>::Primitive,
     ) -> Result<(), MetricsError> {
-        let entry = Entry::from(statistic);
         if statistic.source() == Source::Gauge {
-            if let Some(channel) = self.channels.get(&entry) {
+            if let Some(channel) = self.channels.get(statistic.name()) {
                 channel.record_gauge(time, value);
                 Ok(())
             } else {
@@ -216,11 +213,10 @@ where
     /// distributions it is the percentile across the configured summary.
     pub fn percentile(
         &self,
-        statistic: &dyn Statistic<Value, Count>,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
         percentile: f64,
     ) -> Result<<Value as Atomic>::Primitive, MetricsError> {
-        let entry = Entry::from(statistic);
-        if let Some(channel) = self.channels.get(&entry) {
+        if let Some(channel) = self.channels.get(statistic.name()) {
             channel.percentile(percentile)
         } else {
             Err(MetricsError::NotRegistered)
@@ -232,10 +228,9 @@ where
     // TODO: decide on how to handle distribution channels
     pub fn reading(
         &self,
-        statistic: &dyn Statistic<Value, Count>,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
     ) -> Result<<Value as Atomic>::Primitive, MetricsError> {
-        let entry = Entry::from(statistic);
-        if let Some(channel) = self.channels.get(&entry) {
+        if let Some(channel) = self.channels.get(statistic.name()) {
             channel.reading()
         } else {
             Err(MetricsError::NotRegistered)
@@ -246,21 +241,16 @@ where
     pub fn snapshot(&self) -> HashMap<Metric<Value, Count>, <Value as Atomic>::Primitive> {
         #[allow(unused_mut)]
         let mut result = HashMap::new();
-        for entry in self.outputs.outputs.iter() {
-            let (statistic, outputs) = entry.pair();
-            for output in outputs.iter() {
-                let output = *output.key();
-                let metric = Metric {
-                    statistic: Entry::from(statistic as &dyn Statistic<Value, Count>),
-                    output,
-                };
-                if let Ok(value) = match Output::from(output) {
-                    Output::Reading => self.reading(statistic as &dyn Statistic<Value, Count>),
-                    Output::Percentile(percentile) => self.percentile(statistic, percentile),
-                } {
-                    result.insert(metric, value);
-                }
-            }
+        for entry in &self.channels {
+        	let (_name, channel) = entry.pair();
+        	for output in channel.outputs() {
+        		if let Ok(value) = match Output::from(output) {
+        			Output::Reading => self.reading(channel.statistic() as &dyn Statistic<Value, Count>),
+        			Output::Percentile(percentile) => self.percentile(channel.statistic(), percentile),
+        		} {
+        			result.insert(Metric { statistic: Entry::from(channel.statistic()), output: output.clone()}, value);
+        		}
+        	}
         }
         result
     }

--- a/metrics/src/outputs/mod.rs
+++ b/metrics/src/outputs/mod.rs
@@ -2,66 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::entry::Entry;
-use crate::*;
-use dashmap::{DashMap, DashSet};
-use rustcommon_atomics::Atomic;
-
-pub struct Outputs<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
-    pub(crate) outputs: DashMap<Entry<Value, Count>, DashSet<ApproxOutput>>,
-}
-
-impl<Value, Count> Outputs<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
-    pub fn new() -> Self {
-        Self {
-            outputs: DashMap::new(),
-        }
-    }
-
-    pub fn register(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
-        let entry = Entry::from(statistic);
-        let output = ApproxOutput::from(output);
-        if let Some(outputs) = self.outputs.get(&entry) {
-            outputs.insert(output);
-        } else {
-            let outputs = DashSet::new();
-            outputs.insert(output);
-            self.outputs.insert(entry, outputs);
-        }
-    }
-
-    pub fn deregister(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
-        let entry = Entry::from(statistic);
-        let output = ApproxOutput::from(output);
-        if let Some(outputs) = self.outputs.get(&entry) {
-            outputs.remove(&output);
-        }
-    }
-
-    pub fn deregister_statistic(&self, statistic: &dyn Statistic<Value, Count>) {
-        let entry = Entry::from(statistic);
-        self.outputs.remove(&entry);
-    }
-
-    pub fn clear(&self) {
-        self.outputs.clear()
-    }
-}
-
 // Internal representation which approximates the percentile
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
 pub enum ApproxOutput {


### PR DESCRIPTION
Improve metrics performance by reducing allocations and simplifying metric
lookups.

Improves record_counter() performance by ~120% (~54% latency reduction).
