### PR TITLE
metrics: performance improvements

### DIFF
--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -10,3 +10,10 @@ rustcommon-atomics = { path = "../atomics" }
 rustcommon-heatmap = { path = "../heatmap" }
 rustcommon-streamstats = { path = "../streamstats" }
 thiserror = "1.0.20"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "counters"
+harness = false

--- a/metrics/benches/counters.rs
+++ b/metrics/benches/counters.rs
@@ -1,0 +1,57 @@
+use criterion::Throughput;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rustcommon_metrics::*;
+use std::sync::Arc;
+use std::time::Instant;
+
+enum StatU8 {
+    Alpha,
+    Bravo,
+}
+
+impl Statistic<AtomicU8, AtomicU8> for StatU8 {
+    fn name(&self) -> &str {
+        match self {
+            StatU8::Alpha => "alpha",
+            StatU8::Bravo => "bravo",
+        }
+    }
+
+    fn source(&self) -> Source {
+        match self {
+            StatU8::Alpha => Source::Counter,
+            StatU8::Bravo => Source::Counter,
+        }
+    }
+
+    fn summary(&self) -> Option<Summary<AtomicU8, AtomicU8>> {
+        match self {
+            StatU8::Bravo => Some(Summary::stream(1000)),
+            _ => None,
+        }
+    }
+}
+
+fn u8_u8(c: &mut Criterion) {
+    let metrics = Arc::new(Metrics::<AtomicU8, AtomicU8>::new());
+
+    metrics.register(&StatU8::Alpha);
+    metrics.add_output(&StatU8::Alpha, Output::Reading);
+
+    metrics.register(&StatU8::Bravo);
+    metrics.add_output(&StatU8::Bravo, Output::Reading);
+
+    let mut group = c.benchmark_group("Metrics/AtomicU8/AtomicU8/counter");
+
+    group.throughput(Throughput::Elements(1));
+    let now = Instant::now();
+    group.bench_function("no_summary/record", |b| {
+        b.iter(|| metrics.record_counter(&StatU8::Alpha, now, 255))
+    });
+    group.bench_function("stream/1000/record", |b| {
+        b.iter(|| metrics.record_counter(&StatU8::Bravo, now, 255))
+    });
+}
+
+criterion_group!(benches, u8_u8,);
+criterion_main!(benches);

--- a/metrics/src/entry/mod.rs
+++ b/metrics/src/entry/mod.rs
@@ -10,7 +10,6 @@ use crate::*;
 
 use rustcommon_atomics::Atomic;
 
-#[derive(Clone)]
 pub struct Entry<Value, Count>
 where
     Value: crate::Value,
@@ -23,6 +22,24 @@ where
     source: Source,
     _value: PhantomData<Value>,
     _count: PhantomData<Count>,
+}
+
+impl<Value, Count> Clone for Entry<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            source: self.source,
+            _value: self._value,
+            _count: self._count,
+        }
+    }
 }
 
 impl<Value, Count> Statistic<Value, Count> for Entry<Value, Count>

--- a/metrics/src/outputs/mod.rs
+++ b/metrics/src/outputs/mod.rs
@@ -2,66 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::entry::Entry;
-use crate::*;
-use dashmap::{DashMap, DashSet};
-use rustcommon_atomics::Atomic;
-
-pub struct Outputs<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
-    pub(crate) outputs: DashMap<Entry<Value, Count>, DashSet<ApproxOutput>>,
-}
-
-impl<Value, Count> Outputs<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
-    pub fn new() -> Self {
-        Self {
-            outputs: DashMap::new(),
-        }
-    }
-
-    pub fn register(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
-        let entry = Entry::from(statistic);
-        let output = ApproxOutput::from(output);
-        if let Some(outputs) = self.outputs.get(&entry) {
-            outputs.insert(output);
-        } else {
-            let outputs = DashSet::new();
-            outputs.insert(output);
-            self.outputs.insert(entry, outputs);
-        }
-    }
-
-    pub fn deregister(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
-        let entry = Entry::from(statistic);
-        let output = ApproxOutput::from(output);
-        if let Some(outputs) = self.outputs.get(&entry) {
-            outputs.remove(&output);
-        }
-    }
-
-    pub fn deregister_statistic(&self, statistic: &dyn Statistic<Value, Count>) {
-        let entry = Entry::from(statistic);
-        self.outputs.remove(&entry);
-    }
-
-    pub fn clear(&self) {
-        self.outputs.clear()
-    }
-}
-
 // Internal representation which approximates the percentile
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
 pub enum ApproxOutput {

--- a/metrics/src/summary/mod.rs
+++ b/metrics/src/summary/mod.rs
@@ -50,12 +50,8 @@ where
         percentile: f64,
     ) -> Result<<Value as Atomic>::Primitive, SummaryError> {
         match self {
-            Self::Heatmap(heatmap) => heatmap
-                .percentile(percentile)
-                .map_err(|e| SummaryError::from(e)),
-            Self::Stream(stream) => stream
-                .percentile(percentile)
-                .map_err(|e| SummaryError::from(e)),
+            Self::Heatmap(heatmap) => heatmap.percentile(percentile).map_err(SummaryError::from),
+            Self::Stream(stream) => stream.percentile(percentile).map_err(SummaryError::from),
         }
     }
 

--- a/metrics/src/traits/statistic.rs
+++ b/metrics/src/traits/statistic.rs
@@ -55,7 +55,7 @@ where
     u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.name().to_string() == other.name().to_string()
+        self.name() == other.name()
     }
 }
 


### PR DESCRIPTION
Improve metrics performance by reducing allocations and simplifying metric
lookups.

Improves record_counter() performance by ~120% (~54% latency reduction).
