### PR TITLE
metrics: use crossbeam AtomicCell instead of RwLock

### DIFF
--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 
 [dependencies]
+crossbeam = "0.8.0"
 dashmap = "3.11.10"
 rustcommon-atomics = { path = "../atomics" }
 rustcommon-heatmap = { path = "../heatmap" }


### PR DESCRIPTION
Gets a nice speedup by replacing the RwLock with AtomicCell for the
last refreshed time of the channel.

Increases throughput by ~97% on my laptop.
