### PR TITLE
histogram: improve sub_assign and implement add_assign

### DIFF
--- a/histogram/src/histograms/atomic.rs
+++ b/histogram/src/histograms/atomic.rs
@@ -228,7 +228,6 @@ where
         }
     }
 
-
     /// Convert this `AtomicHistogram` to a non-atomic version by allocating a
     /// new histogram and performing relaxed loads.
     ///

--- a/histogram/src/histograms/atomic.rs
+++ b/histogram/src/histograms/atomic.rs
@@ -159,6 +159,17 @@ where
     }
 
     /// Subtracts another histogram from this histogram
+    ///
+    /// NOTES:
+    /// If the histograms differ in their configured range, we treat the samples
+    /// that were too high on the right hand side as if they would also be too
+    /// high on the histogram those counts are subtracted from. This may produce
+    /// unexpected results if subtracting a histogram with a smaller range from
+    /// one with a wider range.
+    ///
+    /// If the histograms differ in their configured precision, unusual
+    /// artifacts may be introduced by subtracting a low precision histogram
+    /// from one with higher precision.
     pub fn sub_assign(&self, other: &Self) {
         if u64::from(self.max) == u64::from(other.max) && self.precision == other.precision {
             // fast path when histograms have same configuration
@@ -167,14 +178,56 @@ where
                     other.buckets[i].load(Ordering::Relaxed),
                     Ordering::Relaxed,
                 );
+                self.too_high.fetch_saturating_sub(
+                    other.too_high.load(Ordering::Relaxed),
+                    Ordering::Relaxed,
+                );
             }
         } else {
             // slow path if we need to calculate appropriate index for each bucket
             for bucket in other {
                 self.decrement(bucket.value, bucket.count);
             }
+            self.too_high
+                .fetch_saturating_sub(other.too_high.load(Ordering::Relaxed), Ordering::Relaxed);
         }
     }
+
+    /// Adds another histogram to this histogram
+    ///
+    /// NOTES:
+    /// If the histograms differ in their configured range, we treat the samples
+    /// that were too high on the right hand side as if they would also be too
+    /// high on the histogram those counts are added to. This may produce
+    /// unexpected results if adding a histogram with a smaller range to one
+    /// with a wider range.
+    ///
+    /// If the histograms differ in their configured precision, unusual
+    /// artifacts may be introduced by adding a low precision histogram to one
+    /// with higher precision.
+    pub fn add_assign(&self, other: &Self) {
+        if u64::from(self.max) == u64::from(other.max) && self.precision == other.precision {
+            // fast path when histograms have same configuration
+            for i in 0..self.buckets.len() {
+                self.buckets[i].fetch_saturating_add(
+                    other.buckets[i].load(Ordering::Relaxed),
+                    Ordering::Relaxed,
+                );
+                self.too_high.fetch_saturating_add(
+                    other.too_high.load(Ordering::Relaxed),
+                    Ordering::Relaxed,
+                );
+            }
+        } else {
+            // slow path if we need to calculate appropriate index for each bucket
+            for bucket in other {
+                self.increment(bucket.value, bucket.count);
+            }
+            self.too_high
+                .fetch_saturating_add(other.too_high.load(Ordering::Relaxed), Ordering::Relaxed);
+        }
+    }
+
 
     /// Convert this `AtomicHistogram` to a non-atomic version by allocating a
     /// new histogram and performing relaxed loads.

--- a/histogram/src/indexing/u64.rs
+++ b/histogram/src/indexing/u64.rs
@@ -66,7 +66,7 @@ impl crate::Indexing for u64 {
             } else {
                 19
             };
-            let denominator = 10_usize.pow((power - precision as u32 + 1).into());
+            let denominator = 10_usize.pow(power - precision as u32 + 1);
             let power_offset = 9 * exact as usize * (power as usize - precision as usize) / 10;
             let remainder: usize = value as usize / denominator;
             let shift = exact as usize / 10;


### PR DESCRIPTION
Improves sub_assign by addressing out-of-range values and adding
notes about function behaviors.

Adds add_assign method for histograms.

Fixes a clippy lint.
