### PR TITLE
improve buffer api

### DIFF
--- a/buffer/Cargo.toml
+++ b/buffer/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rustcommon-buffer"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"
-description = "Bi-directional buffer for socket communications"
+description = "Bi-directional buffer"
 homepage = "https://github.com/twitter/rustcommon/buffer"
 repository = "https://github.com/twitter/rustcommon"
 

--- a/buffer/README.md
+++ b/buffer/README.md
@@ -7,12 +7,8 @@ Bi-directional buffer
 This crate provides a simple bi-directional buffer which is particularly useful
 for socket communications.
 
-It provides an interface that allows reading from and writing to a type that
-implements Read and Write. It buffers bytes that have been read, enabling access
-to partial reads without calling `peek()`. This is useful for when receive
-traffic may need to be assembled from multiple frames. Writes are also buffered
-before writing the contents out to a sink. This can make it easier to form
-complex transmit traffic, such as serializing to Thrift.
+It acts as both a `BufReader` and `BufWriter`, helping to reduce system call
+overhead by accumulating writes and buffering read results.
 
 ## Getting Started
 

--- a/buffer/src/lib.rs
+++ b/buffer/src/lib.rs
@@ -6,31 +6,36 @@ use bytes::*;
 use std::borrow::Borrow;
 use std::io::*;
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct Buffer {
-    rx: BytesMut,
-    tx: BytesMut,
+    read: BytesMut,
+    write: BytesMut,
     tmp: Vec<u8>,
 }
 
 impl Buffer {
-    pub fn new(rx: usize, tx: usize) -> Buffer {
-        Buffer {
-            rx: BytesMut::with_capacity(rx),
-            tx: BytesMut::with_capacity(tx),
-            tmp: vec![0; rx],
+    pub fn new() -> Buffer {
+        Self::with_capacity(4096, 4096)
+    }
+
+    pub fn with_capacity(read: usize, write: usize) -> Self {
+        Self {
+            read: BytesMut::with_capacity(read),
+            write: BytesMut::with_capacity(write),
+            tmp: vec![0; read],
         }
     }
 
     pub fn clear(&mut self) {
-        self.rx.clear();
-        self.tx.clear();
+        self.read.clear();
+        self.write.clear();
     }
 
     // write from the tx buffer to a given sink
     pub fn write_to<T: Write>(&mut self, sink: &mut T) -> Result<Option<usize>> {
-        match sink.write(self.tx.bytes()) {
+        match sink.write(self.write.bytes()) {
             Ok(bytes) => {
-                self.tx.advance(bytes);
+                self.write.advance(bytes);
                 Ok(Some(bytes))
             }
             Err(e) => {
@@ -47,7 +52,7 @@ impl Buffer {
     pub fn read_from<T: Read>(&mut self, source: &mut T) -> Result<Option<usize>> {
         match source.read(&mut self.tmp) {
             Ok(bytes) => {
-                self.rx.put(&self.tmp[0..bytes]);
+                self.read.put(&self.tmp[0..bytes]);
                 Ok(Some(bytes))
             }
             Err(e) => {
@@ -61,25 +66,29 @@ impl Buffer {
     }
 
     pub fn extend_from_slice(&mut self, extend: &[u8]) {
-        self.tx.extend_from_slice(extend)
+        self.write.extend_from_slice(extend)
     }
 
-    pub fn tx_pending(&self) -> usize {
-        self.tx.len()
+    pub fn write_pending(&self) -> usize {
+        self.write.len()
     }
 
-    pub fn rx_buffer(&self) -> &[u8] {
-        self.rx.borrow()
+    pub fn read_pending(&self) -> usize {
+        self.read.len()
     }
 
-    pub fn tx_buffer(&mut self) -> &mut BytesMut {
-        &mut self.tx
+    pub fn put_slice(&mut self, slice: &[u8]) {
+        self.write.put_slice(slice)
+    }
+
+    pub fn put_u32(&mut self, n: u32) {
+        self.write.put_u32(n)
     }
 }
 
 impl Write for Buffer {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.tx.put_slice(buf);
+        self.write.put_slice(buf);
         Ok(buf.len())
     }
 
@@ -88,10 +97,30 @@ impl Write for Buffer {
     }
 }
 
+impl BufRead for Buffer {
+    fn fill_buf(&mut self) -> Result<&[u8]> {
+        if self.read_pending() > 0 {
+            Ok(self.read.borrow())
+        } else {
+            Err(std::io::Error::new(std::io::ErrorKind::WouldBlock, "Buffer contains no bytes to read"))
+        }
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.read.advance(amt);
+    } 
+}
+
 impl Read for Buffer {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let mut buffer: Cursor<&[u8]> = Cursor::new(self.rx.borrow());
-        buffer.read(buf)
+        let mut buffer: Cursor<&[u8]> = Cursor::new(self.read.borrow());
+        match buffer.read(buf) {
+            Ok(bytes) => {
+                self.read.advance(bytes);
+                Ok(bytes)
+            }
+            Err(e) => Err(e)
+        }
     }
 }
 
@@ -101,7 +130,7 @@ mod test {
 
     #[test]
     fn write_and_write_to() {
-        let mut buffer = Buffer::new(4096, 4096);
+        let mut buffer = Buffer::new();
 
         let messages: Vec<&[u8]> = vec![
             b"break the ice",
@@ -121,7 +150,7 @@ mod test {
 
     #[test]
     fn read_from_and_read() {
-        let mut buffer = Buffer::new(4096, 4096);
+        let mut buffer = Buffer::new();
 
         let mut messages: Vec<&[u8]> = vec![
             b"break the ice",
@@ -138,14 +167,13 @@ mod test {
                 assert_eq!(sink.len(), len); // sink contains the number of bytes read into it
                 assert_eq!(sink.len(), check.len()); // sink has same number of bytes as check string
                 assert_eq!(sink.as_slice(), check); // sink has same data as check string
-                buffer.clear();
             }
         }
     }
 
     #[test]
     fn read_from_multiple() {
-        let mut buffer = Buffer::new(4096, 4096);
+        let mut buffer = Buffer::new();
 
         let mut messages: Vec<&[u8]> = vec![b"brave ", b"new ", b"world"];
 
@@ -160,7 +188,6 @@ mod test {
             assert_eq!(sink.len(), len); // sink contains the number of bytes read into it
             assert_eq!(sink.len(), check.len()); // sink has same number of bytes as check string
             assert_eq!(sink.as_slice(), check); // sink has same data as check string
-            buffer.clear();
         }
         sink.clear();
         if let Ok(len) = buffer.read(&mut sink) {
@@ -168,13 +195,12 @@ mod test {
             sink.truncate(len); // we need to shrink our buffer to match the bytes we've read
             assert_eq!(sink.len(), len); // sink contains the number of bytes read into it
             assert_eq!(sink.as_slice(), b""); // sink has same data as check string
-            buffer.clear();
         }
     }
 
     #[test]
     fn write_to_multiple() {
-        let mut buffer = Buffer::new(4096, 4096);
+        let mut buffer = Buffer::new();
 
         buffer.write(b"DEAD").expect("write failed");
 
@@ -207,7 +233,7 @@ mod test {
 
     #[test]
     fn partial_read() {
-        let mut buffer = Buffer::new(4096, 4096);
+        let mut buffer = Buffer::new();
 
         let mut messages: Vec<&[u8]> = vec![b"DEAD", b"BEEF"];
 
@@ -215,20 +241,20 @@ mod test {
             .read_from(&mut messages[0])
             .expect("read from failed");
 
-        // reading first time should have the contents we just wrote
-        let mut sink = vec![0; 4096];
-        if let Ok(len) = buffer.read(&mut sink) {
-            sink.truncate(len); // we need to shrink our buffer to match the bytes we've read
-            assert_eq!(sink.len(), 4); // sink has same number of bytes as check string
-            assert_eq!(sink.as_slice(), b"DEAD"); // sink has same data as check string
+        // reading with fill_buf() will return the bytes we just wrote
+        if let Ok(content) = buffer.fill_buf() {
+            assert_eq!(content.len(), 4); // sink has same number of bytes as check string
+            assert_eq!(content, b"DEAD"); // sink has same data as check string
+        } else {
+            panic!("buffer had no data");
         }
 
-        // reading again gives us the same result
-        let mut sink = vec![0; 4096];
-        if let Ok(len) = buffer.read(&mut sink) {
-            sink.truncate(len); // we need to shrink our buffer to match the bytes we've read
-            assert_eq!(sink.len(), 4); // sink has same number of bytes as check string
-            assert_eq!(sink.as_slice(), b"DEAD"); // sink has same data as check string
+        // reading again with fill_buf() will still have the same data
+        if let Ok(content) = buffer.fill_buf() {
+            assert_eq!(content.len(), 4); // sink has same number of bytes as check string
+            assert_eq!(content, b"DEAD"); // sink has same data as check string
+        } else {
+            panic!("buffer had no data");
         }
 
         // append to the buffer and read to get all written data
@@ -241,5 +267,7 @@ mod test {
             assert_eq!(sink.len(), 8); // sink has same number of bytes as check string
             assert_eq!(sink.as_slice(), b"DEADBEEF"); // sink has same data as check string
         }
+
+        assert_eq!(buffer.read_pending(), 0);
     }
 }

--- a/buffer/src/lib.rs
+++ b/buffer/src/lib.rs
@@ -102,13 +102,16 @@ impl BufRead for Buffer {
         if self.read_pending() > 0 {
             Ok(self.read.borrow())
         } else {
-            Err(std::io::Error::new(std::io::ErrorKind::WouldBlock, "Buffer contains no bytes to read"))
+            Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "Buffer contains no bytes to read",
+            ))
         }
     }
 
     fn consume(&mut self, amt: usize) {
         self.read.advance(amt);
-    } 
+    }
 }
 
 impl Read for Buffer {
@@ -119,7 +122,7 @@ impl Read for Buffer {
                 self.read.advance(bytes);
                 Ok(bytes)
             }
-            Err(e) => Err(e)
+            Err(e) => Err(e),
         }
     }
 }


### PR DESCRIPTION
Changes the buffer API to have better coherence with the std::io
Read, Write, and BufRead traits.

Fixes that the internal buffer types leaked as a return type.

Changes rx/tx to read/write to make it less tied to sockets.
