### PR TITLE
buffer: enable automatic buffer shrinking

### DIFF
--- a/buffer/Cargo.toml
+++ b/buffer/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/twitter/rustcommon/buffer"
 repository = "https://github.com/twitter/rustcommon"
 
 [dependencies]
-bytes = "0.6.0"
+bytes = "1.0.0"


### PR DESCRIPTION
When used in long-running sessions, we need to address buffer bloat
from handling large requests and responses. This change adds a
private new type that wrapes BufMut providing automatic shrinking
if possible when the buffer is cleared or bytes are consumed.
