### PR TITLE
waterfall: update rusttype to 0.9

### DIFF
--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -15,7 +15,7 @@ image = "0.23.9"
 log = "0.4.8"
 rustcommon-heatmap = { path = "../heatmap" }
 rustcommon-histogram = { path = "../histogram" }
-rusttype = "0.8.3"
+rusttype = "0.9.2"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -12,7 +12,7 @@ use chrono::Utc;
 use image::*;
 use palettes::*;
 use rustcommon_heatmap::*;
-use rusttype::{point, FontCollection, PositionedGlyph, Scale as TypeScale};
+use rusttype::{point, Font, PositionedGlyph, Scale as TypeScale};
 
 use core::hash::Hash;
 use core::ops::Sub;
@@ -252,8 +252,7 @@ pub(crate) struct ColorRgb {
 fn render_text(string: &str, size: f32, x_pos: usize, y_pos: usize, buf: &mut RgbImage) {
     // load font
     let font_data = dejavu::sans_mono::regular();
-    let collection = FontCollection::from_bytes(font_data as &[u8]).unwrap();
-    let font = collection.into_font().unwrap();
+    let font = Font::try_from_bytes(font_data as &[u8]).unwrap();
 
     // size and scaling
     let height: f32 = size;


### PR DESCRIPTION
Updates rusttype library to 0.9 which addresses a rustsec advisory
for an unmaintained transitive dependency.
