### PR TITLE
heatmap: bugfix for AtomicHeatmap

### DIFF
--- a/heatmap/Cargo.toml
+++ b/heatmap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-heatmap"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/heatmap/src/heatmaps/standard.rs
+++ b/heatmap/src/heatmaps/standard.rs
@@ -68,8 +68,10 @@ where
     /// Increment a time-value pair by a specified count
     pub fn increment(&mut self, time: Instant, value: Value, count: Count) {
         self.tick(time);
-        self.slices[self.current].increment(value, count);
-        self.summary.increment(value, count);
+        if let Some(slice) = self.slices.get_mut(self.current) {
+            slice.increment(value, count);
+            self.summary.increment(value, count);
+        }
     }
 
     /// Return the nearest value for the requested percentile (0.0 - 100.0)
@@ -96,8 +98,10 @@ where
                 self.current = 0;
             }
             self.next_tick += self.resolution;
-            self.summary.sub_assign(&self.slices[self.current]);
-            self.slices[self.current].clear();
+            if let Some(slice) = self.slices.get_mut(self.current) {
+                self.summary.sub_assign(slice);
+                slice.clear();
+            }
         }
     }
 

--- a/heatmap/src/window/mod.rs
+++ b/heatmap/src/window/mod.rs
@@ -1,3 +1,7 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use rustcommon_histogram::Histogram;
 use std::time::Instant;
 


### PR DESCRIPTION
We directly access a slice in the heatmap using [] which can cause
a panic if the index is out of bounds.

Changes to .get()/.get_mut() to access the slice and prevent panic
if the slice index is out-of-range.
