### PR TITLE
fastmetrics: improve ergonomics

### DIFF
--- a/fastmetrics/Cargo.toml
+++ b/fastmetrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-fastmetrics"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 

--- a/fastmetrics/benches/counter.rs
+++ b/fastmetrics/benches/counter.rs
@@ -5,11 +5,10 @@
 #[macro_use]
 extern crate rustcommon_fastmetrics;
 
-use rustcommon_fastmetrics::{Source, MetricsBuilder};
 use core::fmt::Display;
 use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Criterion};
-
+use rustcommon_fastmetrics::{MetricsBuilder, Source};
 
 #[derive(Copy, Clone)]
 enum Metric {

--- a/fastmetrics/benches/counter.rs
+++ b/fastmetrics/benches/counter.rs
@@ -2,10 +2,14 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+#[macro_use]
+extern crate rustcommon_fastmetrics;
+
+use rustcommon_fastmetrics::{Source, MetricsBuilder};
 use core::fmt::Display;
 use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Criterion};
-use rustcommon_fastmetrics::*;
+
 
 #[derive(Copy, Clone)]
 enum Metric {

--- a/fastmetrics/src/lib.rs
+++ b/fastmetrics/src/lib.rs
@@ -32,7 +32,7 @@ const UNINITIALIZED: usize = 0;
 const INITIALIZING: usize = 1;
 const INITIALIZED: usize = 2;
 
-pub fn metrics() -> &'static dyn MetricsLib {
+pub fn _metrics() -> &'static dyn MetricsLib {
     unsafe { METRICS }
 }
 
@@ -67,28 +67,16 @@ mod tests {
 
     impl super::Metric for Metric {
         fn source(&self) -> Source {
-            Source::Counter
+            match self {
+                Metric::Alpha | Metric::Bravo => Source::Counter,
+                Metric::Charlie => Source::Gauge,
+            }
         }
 
         fn index(&self) -> usize {
             (*self).into()
         }
     }
-
-    // #[test]
-    // fn counter() {
-    //     let metrics = MetricsBuilder::new()
-    //         .metrics(&[Metric::Alpha, Metric::Charlie])
-    //         .build();
-
-    //     assert_eq!(metrics.get_counter(&Metric::Alpha), Ok(0));
-    //     metrics.set_counter(&Metric::Alpha, 100);
-    //     assert_eq!(metrics.get_counter(&Metric::Alpha), Ok(100));
-
-    //     assert_eq!(metrics.get_counter(&Metric::Charlie), Ok(0));
-    //     metrics.increment_counter(&Metric::Charlie, 1337);
-    //     assert_eq!(metrics.get_counter(&Metric::Charlie), Ok(1337));
-    // }
 
     #[test]
     fn macros() {
@@ -102,5 +90,16 @@ mod tests {
         assert_eq!(get_counter!(&Metric::Alpha), Ok(101));
         increment_counter_by!(&Metric::Alpha, 99);
         assert_eq!(get_counter!(&Metric::Alpha), Ok(200));
+
+        set_gauge!(&Metric::Charlie, 1);
+        assert_eq!(get_gauge!(&Metric::Charlie), Ok(1));
+        increment_gauge!(&Metric::Charlie);
+        assert_eq!(get_gauge!(&Metric::Charlie), Ok(2));
+        increment_gauge_by!(&Metric::Charlie, 40);
+        assert_eq!(get_gauge!(&Metric::Charlie), Ok(42));
+        decrement_gauge!(&Metric::Charlie);
+        assert_eq!(get_gauge!(&Metric::Charlie), Ok(41));
+        decrement_gauge_by!(&Metric::Charlie, 42);
+        assert_eq!(get_gauge!(&Metric::Charlie), Ok(-1));
     }
 }

--- a/fastmetrics/src/macros.rs
+++ b/fastmetrics/src/macros.rs
@@ -7,7 +7,7 @@
 /// See [`Metrics::get_counter()`](struct.Metrics.html#method.get_counter)
 macro_rules! get_counter {
     ($($arg:tt)+) => (
-        metrics().get_counter($($arg)+)
+        $crate::_metrics().get_counter($($arg)+)
     )
 }
 
@@ -16,7 +16,7 @@ macro_rules! get_counter {
 /// See [`Metrics::set_counter()`](struct.Metrics.html#method.set_counter)
 macro_rules! set_counter {
     ($($arg:tt)+) => (
-        metrics().set_counter($($arg)+)
+        $crate::_metrics().set_counter($($arg)+)
     )
 }
 
@@ -25,7 +25,7 @@ macro_rules! set_counter {
 /// See [`Metrics::increment_counter()`](struct.Metrics.html#method.increment_counter_by)
 macro_rules! increment_counter {
     ($($arg:tt)+) => (
-        metrics().increment_counter_by($($arg)+, 1)
+        $crate::_metrics().increment_counter_by($($arg)+, 1)
     )
 }
 
@@ -34,7 +34,7 @@ macro_rules! increment_counter {
 /// See [`Metrics::increment_counter()`](struct.Metrics.html#method.increment_counter_by)
 macro_rules! increment_counter_by {
     ($($arg:tt)+) => (
-        metrics().increment_counter_by($($arg)+)
+        $crate::_metrics().increment_counter_by($($arg)+)
     )
 }
 
@@ -43,7 +43,7 @@ macro_rules! increment_counter_by {
 /// See [`Metrics::get_gauge()`](struct.Metrics.html#method.get_gauge)
 macro_rules! get_gauge {
     ($($arg:tt)+) => (
-        metrics().get_gauge($($arg)+)
+        $crate::_metrics().get_gauge($($arg)+)
     )
 }
 
@@ -52,7 +52,7 @@ macro_rules! get_gauge {
 /// See [`Metrics::set_gauge()`](struct.Metrics.html#method.set_gauge)
 macro_rules! set_gauge {
     ($($arg:tt)+) => (
-        metrics().set_gauge($($arg)+)
+        $crate::_metrics().set_gauge($($arg)+)
     )
 }
 
@@ -61,7 +61,7 @@ macro_rules! set_gauge {
 /// See [`Metrics::increment_gauge()`](struct.Metrics.html#method.increment_gauge_by)
 macro_rules! increment_gauge {
     ($($arg:tt)+) => (
-        metrics().increment_gauge_by($($arg)+, 1)
+        $crate::_metrics().increment_gauge_by($($arg)+, 1)
     )
 }
 
@@ -70,7 +70,7 @@ macro_rules! increment_gauge {
 /// See [`Metrics::increment_gauge()`](struct.Metrics.html#method.increment_gauge_by)
 macro_rules! increment_gauge_by {
     ($($arg:tt)+) => (
-        metrics().increment_gauge_by($($arg)+)
+        $crate::_metrics().increment_gauge_by($($arg)+)
     )
 }
 
@@ -79,7 +79,7 @@ macro_rules! increment_gauge_by {
 /// See [`Metrics::decrement_gauge()`](struct.Metrics.html#method.decrement_gauge_by)
 macro_rules! decrement_gauge {
     ($($arg:tt)+) => (
-        metrics().decrement_gauge_by($($arg)+, 1)
+        $crate::_metrics().decrement_gauge_by($($arg)+, 1)
     )
 }
 
@@ -88,6 +88,6 @@ macro_rules! decrement_gauge {
 /// See [`Metrics::decrement_gauge()`](struct.Metrics.html#method.decrement_gauge_by)
 macro_rules! decrement_gauge_by {
     ($($arg:tt)+) => (
-        metrics().decrement_gauge_by($($arg)+)
+        $crate::_metrics().decrement_gauge_by($($arg)+)
     )
 }


### PR DESCRIPTION
Improves the fastmetrics ergonomics by removing the need to import
`metrics()` into scope.
