### PR TITLE
rustcommon-time: add coarse variants of instant and duration

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-time"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -107,16 +107,14 @@ impl AtomicCoarseInstant {
     }
 }
 
-
 impl CoarseInstant {
     pub fn now() -> Self {
         let now = Instant::now();
         Self {
-            s: (now.ns as f64 / NS_PER_SECOND as f64).round() as u32
+            s: (now.ns as f64 / NS_PER_SECOND as f64).round() as u32,
         }
     }
 }
-
 
 impl CoarseInstant {
     pub fn elapsed(&self) -> CoarseDuration {


### PR DESCRIPTION
Adds coarse variants of instant and duration for cases where we do
not need high resolution times.
