### PR TITLE
rustcommon-time: derive common traits for duration types

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-time"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -333,6 +333,7 @@ impl std::ops::SubAssign<Duration> for Instant {
 
 /// `CoarseDuration` is a lower-resolution version of `Duration`. It represents
 /// a period of time with one-second resolution.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct CoarseDuration {
     s: u32,
 }
@@ -344,6 +345,7 @@ impl CoarseDuration {
 }
 
 /// `Duration` is the amount of time between two instants.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Duration {
     ns: u64,
 }


### PR DESCRIPTION
Derive common traits for duration types.
