### PR TITLE
rustcommon-time: add duration constructors and constants

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-time"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Adds constructors and constants for duration types
