### PR TITLE
rustcommon-time: add methods to return recent instants

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-time"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Problem

For frequent timestamping where we don't need the current clock reading,
we can use a cached recent value.

Solution

This is accomplished by adding an internal clock struct which contains a
cached reading of the underlying clock. We then add `Instant::recent()`
and `CoarseInstant::recent()` functions to construct new instants from
the cached view of the clock.

The cached clock must be periodically refreshed by using the public
`refresh_clock()` function.
