### PR TITLE
ratelimiter: fix issues with token accounting

### DIFF
--- a/ratelimiter/src/lib.rs
+++ b/ratelimiter/src/lib.rs
@@ -119,12 +119,15 @@ impl Ratelimiter {
                 Ok(Refill::Normal) => self.normal.sample(&mut rand::thread_rng()) as u64,
                 Err(_) => self.tick.load(Ordering::Relaxed),
             };
-            self.next.fetch_add(tick, Ordering::Relaxed);
-            self.available
-                .fetch_add(self.quantum.load(Ordering::Relaxed), Ordering::Relaxed);
-            if self.available.load(Ordering::Relaxed) > self.capacity.load(Ordering::Relaxed) {
-                self.available
-                    .store(self.capacity.load(Ordering::Relaxed), Ordering::Relaxed);
+            if self.next.compare_exchange(next, next + tick, Ordering::AcqRel, Ordering::Relaxed).is_ok() {
+                let quantum = self.quantum.load(Ordering::Relaxed);
+                let capacity = self.capacity.load(Ordering::Relaxed);
+                let available = self.available.load(Ordering::Relaxed);
+                if available + quantum >= capacity {
+                    self.available.store(capacity, Ordering::Release);
+                } else {
+                    self.available.fetch_add(quantum, Ordering::Release);
+                }
             }
         }
     }


### PR DESCRIPTION
The available token accounting had some bugs which could enable too
many tokens to be in the bucket for highly contended ratelimiters.

This change replaces the fetch_add accounting for the tick with a
compare exchange which serves to eliminate races when updating the
available token count. This removes the potential for phantom
tokens to be added to the bucket if the available tokens were
reduced while doing the two step saturating add.

This should result in more accurate ratelimiting.
