### PR TITLE
atomics: remove compare_and_swap()

### DIFF
--- a/atomics/src/macros/float.rs
+++ b/atomics/src/macros/float.rs
@@ -47,15 +47,6 @@ macro_rules! float {
             }
 
             #[inline]
-            fn compare_and_swap(&self, current: Self::Primitive, new: Self::Primitive, ordering: Ordering) -> Self::Primitive {
-                <$type>::from_bits(self.inner.compare_and_swap(
-                    current.to_bits(),
-                    new.to_bits(),
-                    ordering,
-                ))
-            }
-
-            #[inline]
             fn compare_exchange(
                 &self,
                 current: Self::Primitive,

--- a/atomics/src/macros/float_arithmetic.rs
+++ b/atomics/src/macros/float_arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -19,14 +19,20 @@ macro_rules! float_arithmetic {
                 let current = self.inner.load(load_ordering);
                 let mut new = <$type>::from_bits(current) + value;
                 loop {
-                    let result = self
-                        .inner
-                        .compare_and_swap(current, new.to_bits(), ordering);
-                    if result == current {
-                        // value updated, return
-                        return <$type>::from_bits(current);
+                    let result = self.inner.compare_exchange(
+                        current,
+                        new.to_bits(),
+                        ordering,
+                        load_ordering,
+                    );
+                    match result {
+                        Ok(v) => {
+                            return <$type>::from_bits(v);
+                        }
+                        Err(v) => {
+                            new = <$type>::from_bits(v) + value;
+                        }
                     }
-                    new = <$type>::from_bits(result) + value;
                 }
             }
 
@@ -44,14 +50,20 @@ macro_rules! float_arithmetic {
                 let current = self.inner.load(load_ordering);
                 let mut new = <$type>::from_bits(current) - value;
                 loop {
-                    let result = self
-                        .inner
-                        .compare_and_swap(current, new.to_bits(), ordering);
-                    if result == current {
-                        // value updated, return
-                        return <$type>::from_bits(current);
+                    let result = self.inner.compare_exchange(
+                        current,
+                        new.to_bits(),
+                        ordering,
+                        load_ordering,
+                    );
+                    match result {
+                        Ok(v) => {
+                            return <$type>::from_bits(v);
+                        }
+                        Err(v) => {
+                            new = <$type>::from_bits(v) - value;
+                        }
                     }
-                    new = <$type>::from_bits(result) - value;
                 }
             }
         }

--- a/atomics/src/macros/float_saturating_arithmetic.rs
+++ b/atomics/src/macros/float_saturating_arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -25,16 +25,19 @@ macro_rules! saturating_arithmetic {
                         } else {
                             sum
                         };
-                        let result = self.compare_and_swap(previous, new, ordering);
-                        if result == previous {
-                            // value updated, return previous.
-                            return previous;
-                        }
-                        previous = result;
-                        if previous == <$type>::max_value() {
-                            // value concurrently updated and now at numeric bound.
-                            // return its new value as the previous value.
-                            return previous;
+                        let result = self.compare_exchange(previous, new, ordering, load_ordering);
+                        match result {
+                            Ok(v) => {
+                                return v;
+                            }
+                            Err(v) => {
+                                previous = v;
+                                if previous == <$type>::max_value() {
+                                    // value concurrently updated and now at numeric bound.
+                                    // return its new value as the previous value.
+                                    return previous;
+                                }
+                            }
                         }
                     }
                 }
@@ -59,16 +62,19 @@ macro_rules! saturating_arithmetic {
                         } else {
                             diff
                         };
-                        let result = self.compare_and_swap(previous, new, ordering);
-                        if result == previous {
-                            // value updated, return previous.
-                            return previous;
-                        }
-                        previous = result;
-                        if previous == <$type>::min_value() {
-                            // value concurrently updated, and now at numeric bound.
-                            // return its new value as the previous value.
-                            return previous;
+                        let result = self.compare_exchange(previous, new, ordering, load_ordering);
+                        match result {
+                            Ok(v) => {
+                                return v;
+                            }
+                            Err(v) => {
+                                previous = v;
+                                if previous == <$type>::max_value() {
+                                    // value concurrently updated and now at numeric bound.
+                                    // return its new value as the previous value.
+                                    return previous;
+                                }
+                            }
                         }
                     }
                 }

--- a/atomics/src/macros/native.rs
+++ b/atomics/src/macros/native.rs
@@ -47,11 +47,6 @@ macro_rules! native {
             }
 
             #[inline]
-            fn compare_and_swap(&self, current: Self::Primitive, new: Self::Primitive, ordering: Ordering) -> Self::Primitive {
-                self.inner.compare_and_swap(current, new, ordering)
-            }
-
-            #[inline]
             fn compare_exchange(
                 &self,
                 current: Self::Primitive,

--- a/atomics/src/macros/saturating_arithmetic.rs
+++ b/atomics/src/macros/saturating_arithmetic.rs
@@ -23,16 +23,19 @@ macro_rules! saturating_arithmetic {
                 } else {
                     loop {
                         let new = previous.saturating_add(value);
-                        let result = self.compare_and_swap(previous, new, ordering);
-                        if result == previous {
-                            // value updated, return previous.
-                            return previous;
-                        }
-                        previous = result;
-                        if previous == <$type>::max_value() {
-                            // value concurrently updated and now at numeric bound.
-                            // return its new value as the previous value.
-                            return previous;
+                        let result = self.compare_exchange(previous, new, ordering, load_ordering);
+                        match result {
+                            Ok(v) => {
+                                return v;
+                            }
+                            Err(v) => {
+                                previous = v;
+                                if previous == <$type>::max_value() {
+                                    // value concurrently updated and now at numeric bound.
+                                    // return its new value as the previous value.
+                                    return previous;
+                                }
+                            }
                         }
                     }
                 }
@@ -56,16 +59,19 @@ macro_rules! saturating_arithmetic {
                 } else {
                     loop {
                         let new = previous.saturating_sub(value);
-                        let result = self.compare_and_swap(previous, new, ordering);
-                        if result == previous {
-                            // value updated, return previous.
-                            return previous;
-                        }
-                        previous = result;
-                        if previous == <$type>::min_value() {
-                            // value concurrently updated, and now at numeric bound.
-                            // return its new value as the previous value.
-                            return previous;
+                        let result = self.compare_exchange(previous, new, ordering, load_ordering);
+                        match result {
+                            Ok(v) => {
+                                return v;
+                            }
+                            Err(v) => {
+                                previous = v;
+                                if previous == <$type>::max_value() {
+                                    // value concurrently updated and now at numeric bound.
+                                    // return its new value as the previous value.
+                                    return previous;
+                                }
+                            }
                         }
                     }
                 }

--- a/atomics/src/traits/atomic.rs
+++ b/atomics/src/traits/atomic.rs
@@ -33,25 +33,6 @@ pub trait Atomic {
     fn swap(&self, value: Self::Primitive, order: Ordering) -> Self::Primitive;
 
     /// Stores a value into the atomic type if the current value is the same as
-    /// the `current` value.
-    ///
-    /// The return value is always the previous value. If it is equal to
-    /// `current`, then the value was updated.
-    ///
-    /// `compare_and_swap` takes an `Ordering` argument which describes the
-    /// memory ordering of this operation. Note that even when using `AcqRel`,
-    /// the operation might fail and hence just perform an `Acquire` load, but
-    /// not have `Release` semantics. Using `Acquire` makes the store part of
-    /// this operation `Relaxed` if it happens, and using `Release` makes the
-    /// load part `Relaxed`.
-    fn compare_and_swap(
-        &self,
-        current: Self::Primitive,
-        new: Self::Primitive,
-        order: Ordering,
-    ) -> Self::Primitive;
-
-    /// Stores a value into the atomic type if the current value is the same as
     /// as the `current` value.
     ///
     /// The return value is a result indicating whether the new value was

--- a/atomics/src/types/f32.rs
+++ b/atomics/src/types/f32.rs
@@ -166,13 +166,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicF32::new(0.0);
-        assert_eq!(atomic.compare_and_swap(0.0, 3.14, Ordering::SeqCst), 0.0);
-        assert_eq!(atomic.compare_and_swap(0.0, 42.0, Ordering::SeqCst), 3.14);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicF32::new(0.0);
         assert_eq!(

--- a/atomics/src/types/f64.rs
+++ b/atomics/src/types/f64.rs
@@ -152,13 +152,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicF64::new(0.0);
-        assert_eq!(atomic.compare_and_swap(0.0, 3.14, Ordering::SeqCst), 0.0);
-        assert_eq!(atomic.compare_and_swap(0.0, 42.0, Ordering::SeqCst), 3.14);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicF64::new(0.0);
         assert_eq!(

--- a/atomics/src/types/i16.rs
+++ b/atomics/src/types/i16.rs
@@ -158,13 +158,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicI16::new(0);
-        assert_eq!(atomic.compare_and_swap(0, 1, Ordering::SeqCst), 0);
-        assert_eq!(atomic.compare_and_swap(0, 2, Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicI16::new(0);
         assert_eq!(

--- a/atomics/src/types/i32.rs
+++ b/atomics/src/types/i32.rs
@@ -148,13 +148,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicI32::new(0);
-        assert_eq!(atomic.compare_and_swap(0, 1, Ordering::SeqCst), 0);
-        assert_eq!(atomic.compare_and_swap(0, 2, Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicI32::new(0);
         assert_eq!(

--- a/atomics/src/types/i64.rs
+++ b/atomics/src/types/i64.rs
@@ -138,13 +138,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicI64::new(0);
-        assert_eq!(atomic.compare_and_swap(0, 1, Ordering::SeqCst), 0);
-        assert_eq!(atomic.compare_and_swap(0, 2, Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicI64::new(0);
         assert_eq!(

--- a/atomics/src/types/i8.rs
+++ b/atomics/src/types/i8.rs
@@ -168,13 +168,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicI8::new(0);
-        assert_eq!(atomic.compare_and_swap(0, 1, Ordering::SeqCst), 0);
-        assert_eq!(atomic.compare_and_swap(0, 2, Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicI8::new(0);
         assert_eq!(

--- a/atomics/src/types/isize.rs
+++ b/atomics/src/types/isize.rs
@@ -158,13 +158,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicIsize::new(0);
-        assert_eq!(atomic.compare_and_swap(0, 1, Ordering::SeqCst), 0);
-        assert_eq!(atomic.compare_and_swap(0, 2, Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicIsize::new(0);
         assert_eq!(

--- a/atomics/src/types/u16.rs
+++ b/atomics/src/types/u16.rs
@@ -163,13 +163,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicU16::new(0);
-        assert_eq!(atomic.compare_and_swap(0, 1, Ordering::SeqCst), 0);
-        assert_eq!(atomic.compare_and_swap(0, 2, Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicU16::new(0);
         assert_eq!(

--- a/atomics/src/types/u32.rs
+++ b/atomics/src/types/u32.rs
@@ -158,13 +158,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicU32::new(0);
-        assert_eq!(atomic.compare_and_swap(0, 1, Ordering::SeqCst), 0);
-        assert_eq!(atomic.compare_and_swap(0, 2, Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicU32::new(0);
         assert_eq!(

--- a/atomics/src/types/u64.rs
+++ b/atomics/src/types/u64.rs
@@ -153,13 +153,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicU64::new(0);
-        assert_eq!(atomic.compare_and_swap(0, 1, Ordering::SeqCst), 0);
-        assert_eq!(atomic.compare_and_swap(0, 2, Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicU64::new(0);
         assert_eq!(

--- a/atomics/src/types/u8.rs
+++ b/atomics/src/types/u8.rs
@@ -168,13 +168,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicU8::new(0);
-        assert_eq!(atomic.compare_and_swap(0, 1, Ordering::SeqCst), 0);
-        assert_eq!(atomic.compare_and_swap(0, 2, Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicU8::new(0);
         assert_eq!(

--- a/atomics/src/types/usize.rs
+++ b/atomics/src/types/usize.rs
@@ -168,13 +168,6 @@ mod tests {
     }
 
     #[test]
-    fn compare_and_swap() {
-        let atomic = AtomicUsize::new(0);
-        assert_eq!(atomic.compare_and_swap(0, 1, Ordering::SeqCst), 0);
-        assert_eq!(atomic.compare_and_swap(0, 2, Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn compare_exchange() {
         let atomic = AtomicUsize::new(0);
         assert_eq!(

--- a/streamstats/src/lib.rs
+++ b/streamstats/src/lib.rs
@@ -60,9 +60,9 @@ where
             } else {
                 0
             };
-            let result = self
-                .current
-                .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed);
+            let result =
+                self.current
+                    .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed);
             match result {
                 Ok(_) => {
                     break;

--- a/streamstats/src/lib.rs
+++ b/streamstats/src/lib.rs
@@ -60,13 +60,16 @@ where
             } else {
                 0
             };
-            let previous = self
+            let result = self
                 .current
-                .compare_and_swap(current, next, Ordering::Relaxed);
-            if previous == current {
-                break;
-            } else {
-                current = previous;
+                .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed);
+            match result {
+                Ok(_) => {
+                    break;
+                }
+                Err(v) => {
+                    current = v;
+                }
             }
         }
         if self.len.load(Ordering::Relaxed) < self.buffer.len() {


### PR DESCRIPTION
Compare and swap in core is deprecated. Removes compare and swap
and migrates all internal use to compare exchange.

Simplifies fetch max and min functions to use the stabilized
functions in core.