### PR TITLE
time: normalize interfaces with core/std

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-time"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 

--- a/time/src/duration/coarse/atomic.rs
+++ b/time/src/duration/coarse/atomic.rs
@@ -1,0 +1,267 @@
+use crate::*;
+use core::sync::atomic::AtomicU32;
+
+/// An `AtomicCoarseDuration` is an atomic equivalent of [`CoarseDuration`].
+///
+/// # Examples
+///
+/// ```
+/// use rustcommon_time::{AtomicCoarseDuration, CoarseDuration};
+/// use core::sync::atomic::Ordering;
+///
+/// let one_second = AtomicCoarseDuration::new(1);
+/// assert_eq!(one_second.load(Ordering::Relaxed).as_secs(), 1);
+///
+/// let ten_seconds = AtomicCoarseDuration::from_secs(10);
+/// ```
+pub struct AtomicCoarseDuration {
+    secs: AtomicU32,
+}
+
+impl AtomicCoarseDuration {
+    /// Creates a new `Duration` from the specified number of whole seconds and
+    /// additional nanoseconds.
+    ///
+    /// If the number of nanoseconds is greater than 1 billion (the number of
+    /// nanoseconds in a second), then it will carry over into the seconds
+    /// provided.
+    ///
+    /// # Panics
+    ///
+    /// This constructor will panic if the carry from the nanoseconds overflows
+    /// the seconds counter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let five_seconds = Duration::new(5, 0);
+    /// ```
+    #[inline]
+    pub fn new(secs: u32) -> Self {
+        Self {
+            secs: AtomicU32::new(secs),
+        }
+    }
+
+    /// Creates a new `AtomicDuration` from the specified number of whole seconds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::from_secs(5);
+    ///
+    /// assert_eq!(5, duration.as_secs());
+    /// assert_eq!(0, duration.subsec_nanos());
+    /// ```
+    #[inline]
+    pub const fn from_secs(secs: u32) -> Self {
+        Self {
+            secs: AtomicU32::new(secs),
+        }
+    }
+
+    /// Consumes the atomic and returns the contained value.
+    ///
+    /// This is safe because passing `self` by value guarantees that no other
+    /// threads are concurrently accessing the atomic data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicCoarseDuration, CoarseDuration};
+    ///
+    /// let duration = AtomicCoarseDuration::from_secs(1337);
+    /// assert_eq!(duration.into_inner(), CoarseDuration::from_secs(1337));
+    /// ```
+    pub fn into_inner(self) -> CoarseDuration {
+        CoarseDuration {
+            secs: self.secs.into_inner(),
+        }
+    }
+
+    /// Loads the duration from the atomic duration.
+    ///
+    /// `load` takes an `Ordering` argument which describes the memory ordering
+    /// of this operation. Possible values are `SeqCst`, `Acquire`, and
+    /// `Relaxed`.
+    ///
+    /// # Panics
+    /// Panics if `order` is `Release` or `AcqRel`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicCoarseDuration, CoarseDuration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicCoarseDuration::from_secs(5);
+    /// assert_eq!(duration.load(Ordering::Relaxed), CoarseDuration::from_secs(5));
+    /// ```
+    pub fn load(&self, order: Ordering) -> CoarseDuration {
+        CoarseDuration {
+            secs: self.secs.load(order),
+        }
+    }
+
+    /// Stores the duration from the atomic duration.
+    ///
+    /// `store` takes an `Ordering` argument which describes the memory ordering
+    /// of this operation. Possible values are `SeqCst`, `Release`, and
+    /// `Relaxed`.
+    ///
+    /// # Panics
+    /// Panics if `order` is `Acquire` or `AcqRel`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicCoarseDuration, CoarseDuration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicCoarseDuration::from_secs(5);
+    ///
+    /// duration.store(CoarseDuration::from_secs(10), Ordering::Relaxed);
+    /// assert_eq!(duration.load(Ordering::Relaxed), CoarseDuration::from_secs(10));
+    /// ```
+    pub fn store(&self, val: CoarseDuration, order: Ordering) {
+        self.secs.store(val.secs, order)
+    }
+
+    /// Stores the duration from the atomic duration, returning the previous
+    /// value.
+    ///
+    /// `swap` takes an `Ordering` argument which describes the memory ordering
+    /// of this operation. All ordering modes are possible. Note that using
+    /// `Acquire` makes the store part of this operation `Relaxed`, and using
+    /// `Release` makes the load part `Relaxed`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicCoarseDuration, CoarseDuration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicCoarseDuration::from_secs(5);
+    ///
+    /// assert_eq!(duration.swap(CoarseDuration::from_secs(10), Ordering::Relaxed), CoarseDuration::from_secs(5));
+    /// ```
+    pub fn swap(&self, val: CoarseDuration, order: Ordering) -> CoarseDuration {
+        CoarseDuration {
+            secs: self.secs.swap(val.secs, order),
+        }
+    }
+
+    /// Stores the duration from the atomic duration if the current value is the
+    /// same as the `current` value.
+    ///
+    /// The return value is a result indicating whether the new value was
+    /// written and containing the previous value. On success this value is
+    /// guaranteed to be equal to current.
+    ///
+    /// `compare_exchange` takes two `Ordering` arguments to describe the memory
+    /// ordering of this operation. `success` describes the required ordering
+    /// for the read-modify-write operation that takes place if the comparison
+    /// with `current` succeeds. `failure` describes the required ordering for
+    /// the load operation that takes place when the comparison fails. Using
+    /// `Acquire` as success ordering makes the store part of this operation
+    /// `Relaxed`, and using `Release makes the successful load `Relaxed`. The
+    /// failure ordering can only be, `SeqCst`, `Acquire`, or `Relaxed` and must
+    /// be equivalent to or weaker than the success ordering.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicCoarseDuration, CoarseDuration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicCoarseDuration::from_secs(5);
+    ///
+    /// assert_eq!(duration.compare_exchange(
+    ///     CoarseDuration::from_secs(5),
+    ///     CoarseDuration::from_secs(10),
+    ///     Ordering::Acquire,
+    ///     Ordering::Relaxed),
+    ///     Ok(CoarseDuration::from_secs(5)));
+    /// assert_eq!(duration.load(Ordering::Relaxed), CoarseDuration::from_secs(10));
+    ///
+    /// assert_eq!(duration.compare_exchange(
+    ///     CoarseDuration::from_secs(6),
+    ///     CoarseDuration::from_secs(12),
+    ///     Ordering::Acquire,
+    ///     Ordering::Relaxed),
+    ///     Err(CoarseDuration::from_secs(10)));
+    /// assert_eq!(duration.load(Ordering::Relaxed), CoarseDuration::from_secs(10));
+    ///
+    /// ```
+    pub fn compare_exchange(
+        &self,
+        current: CoarseDuration,
+        new: CoarseDuration,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<CoarseDuration, CoarseDuration> {
+        match self
+            .secs
+            .compare_exchange(current.secs, new.secs, success, failure)
+        {
+            Ok(secs) => Ok(CoarseDuration { secs }),
+            Err(secs) => Err(CoarseDuration { secs }),
+        }
+    }
+
+    /// Stores the duration from the atomic duration if the current value is the
+    /// same as the `current` value.
+    ///
+    /// Unlike `AtomicCoarseDuration::compare_exchange`, this function is
+    /// allowed to spuriously fail even when the comparison succeeds, which can
+    /// result in more efficient code on some platforms. The return value is a
+    /// result indicating whether the new value was written and containing the
+    /// previous value.
+    ///
+    /// `compare_exchange_weak` takes two `Ordering` arguments to describe the
+    /// memory ordering of this operation. `success` describes the required
+    /// ordering for the read-modify-write operation that takes place if the
+    /// comparison with `current` succeeds. `failure` describes the required
+    /// ordering for the load operation that takes place when the comparison
+    /// fails. Using `Acquire` as success ordering makes the store part of this
+    /// operation `Relaxed`, and using `Release makes the successful load
+    /// `Relaxed`. The failure ordering can only be, `SeqCst`, `Acquire`, or
+    /// `Relaxed` and must be equivalent to or weaker than the success ordering.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicCoarseDuration, CoarseDuration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicCoarseDuration::from_secs(5);
+    ///
+    /// let mut old = duration.load(Ordering::Relaxed);
+    /// loop {
+    ///     let new = old.saturating_mul(2);
+    ///     match duration.compare_exchange_weak(old, new, Ordering::SeqCst, Ordering::Relaxed) {
+    ///         Ok(_) => break,
+    ///         Err(x) => old = x,
+    ///     }
+    /// }
+    /// ```
+    pub fn compare_exchange_weak(
+        &self,
+        current: CoarseDuration,
+        new: CoarseDuration,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<CoarseDuration, CoarseDuration> {
+        match self
+            .secs
+            .compare_exchange_weak(current.secs, new.secs, success, failure)
+        {
+            Ok(secs) => Ok(CoarseDuration { secs }),
+            Err(secs) => Err(CoarseDuration { secs }),
+        }
+    }
+}

--- a/time/src/duration/coarse/mod.rs
+++ b/time/src/duration/coarse/mod.rs
@@ -1,0 +1,5 @@
+mod atomic;
+mod plain;
+
+pub use atomic::*;
+pub use plain::*;

--- a/time/src/duration/coarse/plain.rs
+++ b/time/src/duration/coarse/plain.rs
@@ -1,0 +1,442 @@
+//! Temporal quantification.
+//!
+//! Example:
+//!
+//! ```
+//! use rustcommon_time::Duration;
+//!
+//! let five_seconds = Duration::new(5, 0);
+//! // both declarations are equivalent
+//! assert_eq!(Duration::new(5, 0), Duration::from_secs(5));
+//! ```
+
+use core::fmt;
+use core::iter::Sum;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
+use crate::*;
+
+/// A `CoarseDuration` type to represent a span of time with a resolution of one
+/// second in a 32 bit value. This is appropriate for representing things such
+/// as object expiration in a cache.
+///
+/// Each `CoarseDuration` is composed of a whole number of seconds.
+///
+/// [`CoarseDuration`]s implement many common traits, including [`Add`],
+/// [`Sub`], and other [`ops`] traits. It implements [`Default`] by returning a
+/// zero-length `CoarseDuration`.
+///
+/// [`ops`]: core::ops
+///
+/// # Examples
+///
+/// ```
+/// use rustcommon_time::CoarseDuration;
+///
+/// let five_seconds = CoarseDuration::new(5);
+///
+/// assert_eq!(five_seconds.as_secs(), 5);
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct CoarseDuration {
+    pub(crate) secs: u32,
+}
+
+impl CoarseDuration {
+    /// The duration of one second.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// assert_eq!(CoarseDuration::SECOND, CoarseDuration::from_secs(1));
+    /// ```
+    pub const SECOND: Self = Self::from_secs(1);
+
+    /// A duration of zero time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// let duration = CoarseDuration::ZERO;
+    /// assert!(duration.is_zero());
+    /// assert_eq!(duration.as_nanos(), 0);
+    /// ```
+    pub const ZERO: Self = Self::from_secs(0);
+
+    /// The maximum duration.
+    ///
+    /// It is roughly equal to a duration of 136.192 years.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// assert_eq!(CoarseDuration::MAX, CoarseDuration::new(u32::MAX));
+    /// ```
+    pub const MAX: Self = Self::from_secs(u32::MAX);
+
+    /// Creates a new `CoarseDuration` from the specified number of whole
+    /// seconds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// let five_seconds = CoarseDuration::new(5);
+    /// ```
+    #[inline]
+    pub const fn new(secs: u32) -> Self {
+        Self { secs }
+    }
+
+    /// Creates a new `Duration` from the specified number of whole seconds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// let duration = CoarseDuration::from_secs(5);
+    ///
+    /// assert_eq!(5, duration.as_secs());
+    /// ```
+    #[inline]
+    pub const fn from_secs(secs: u32) -> Self {
+        Self { secs }
+    }
+
+    /// Returns true if this `CoarseDuration` spans no time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// assert!(CoarseDuration::ZERO.is_zero());
+    /// assert!(CoarseDuration::new(0).is_zero());
+    /// assert!(CoarseDuration::from_secs(0).is_zero());
+    ///
+    /// assert!(!CoarseDuration::new(1).is_zero());
+    /// assert!(!CoarseDuration::from_secs(1).is_zero());
+    /// ```
+    #[inline]
+    pub const fn is_zero(&self) -> bool {
+        self.secs == 0
+    }
+
+    /// Returns the number of seconds contained by this `CoarseDuration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// let duration = CoarseDuration::new(5);
+    /// assert_eq!(duration.as_secs(), 5);
+    /// ```
+    #[inline]
+    pub const fn as_secs(&self) -> u32 {
+        self.secs
+    }
+
+    /// Returns the total number of whole milliseconds contained by this
+    /// `CoarseDuration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// let duration = CoarseDuration::new(5);
+    /// assert_eq!(duration.as_millis(), 5000);
+    /// ```
+    #[inline]
+    pub const fn as_millis(&self) -> u64 {
+        self.secs as u64 * MILLIS_PER_SEC
+    }
+
+    /// Returns the total number of whole microseconds contained by this
+    /// `CoarseDuration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// let duration = CoarseDuration::new(5);
+    /// assert_eq!(duration.as_micros(), 5000000);
+    /// ```
+    #[inline]
+    pub const fn as_micros(&self) -> u64 {
+        self.secs as u64 * MICROS_PER_SEC
+    }
+
+    /// Returns the total number of nanoseconds contained by this
+    /// `CoarseDuration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// let duration = CoarseDuration::new(5);
+    /// assert_eq!(duration.as_nanos(), 5000000000);
+    /// ```
+    #[inline]
+    pub const fn as_nanos(&self) -> u64 {
+        self.secs as u64 * NANOS_PER_SEC
+    }
+
+    /// Checked `CoarseDuration` addition. Computes `self + other`, returning
+    /// [`None`] if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// assert_eq!(CoarseDuration::new(1).checked_add(CoarseDuration::new(2)), Some(CoarseDuration::new(3)));
+    /// assert_eq!(CoarseDuration::new(1).checked_add(CoarseDuration::new(u32::MAX)), None);
+    /// ```
+    #[inline]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        if let Some(secs) = self.secs.checked_add(rhs.secs) {
+            Some(Self { secs })
+        } else {
+            None
+        }
+    }
+
+    /// Saturating `CoarseDuration` addition. Computes `self + other`, returning
+    /// [`CoarseDuration::MAX`] if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// assert_eq!(CoarseDuration::new(1).saturating_add(CoarseDuration::new(2)), CoarseDuration::new(3));
+    /// assert_eq!(CoarseDuration::new(1).saturating_add(CoarseDuration::new(u32::MAX)), CoarseDuration::MAX);
+    /// ```
+    #[inline]
+    pub const fn saturating_add(self, rhs: Self) -> Self {
+        match self.checked_add(rhs) {
+            Some(res) => res,
+            None => Self::MAX,
+        }
+    }
+
+    /// Checked `CoarseDuration` subtraction. Computes `self - other`, returning
+    /// [`None`] if the result would be negative or if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// assert_eq!(CoarseDuration::new(3).checked_sub(CoarseDuration::new(2)), Some(CoarseDuration::new(1)));
+    /// assert_eq!(CoarseDuration::new(0).checked_sub(CoarseDuration::new(1)), None);
+    /// ```
+    #[inline]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        if let Some(secs) = self.secs.checked_sub(rhs.secs) {
+            Some(Self { secs })
+        } else {
+            None
+        }
+    }
+
+    /// Saturating `CoarseDuration` subtraction. Computes `self - other`,
+    /// returning [`CoarseDuration::ZERO`] if the result would be negative or
+    /// if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// assert_eq!(CoarseDuration::new(3).saturating_sub(CoarseDuration::new(2)), CoarseDuration::new(1));
+    /// assert_eq!(CoarseDuration::new(0).saturating_sub(CoarseDuration::new(1)), CoarseDuration::ZERO);
+    /// ```
+    #[inline]
+    pub const fn saturating_sub(self, rhs: Self) -> Self {
+        match self.checked_sub(rhs) {
+            Some(res) => res,
+            None => Self::ZERO,
+        }
+    }
+
+    /// Checked `CoarseDuration` multiplication. Computes `self * other`,
+    /// returning [`None`] if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// assert_eq!(CoarseDuration::new(1).checked_mul(2), Some(CoarseDuration::new(2)));
+    /// assert_eq!(CoarseDuration::new(u32::MAX - 1).checked_mul(2), None);
+    /// ```
+    #[inline]
+    pub const fn checked_mul(self, rhs: u32) -> Option<Self> {
+        if let Some(secs) = self.secs.checked_mul(rhs) {
+            Some(Self { secs })
+        } else {
+            None
+        }
+    }
+
+    /// Saturating `CoarseDuration` multiplication. Computes `self * other`,
+    /// returning [`Duration::MAX`] if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// assert_eq!(CoarseDuration::new(1).saturating_mul(2), CoarseDuration::new(2));
+    /// assert_eq!(CoarseDuration::new(u32::MAX - 1).saturating_mul(2), CoarseDuration::MAX);
+    /// ```
+    #[inline]
+    pub const fn saturating_mul(self, rhs: u32) -> Self {
+        match self.checked_mul(rhs) {
+            Some(res) => res,
+            None => Self::MAX,
+        }
+    }
+
+    /// Checked `CoarseDuration` division. Computes `self / other`, returning
+    /// [`None`] if `other == 0`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseDuration;
+    ///
+    /// assert_eq!(CoarseDuration::new(2).checked_div(2), Some(CoarseDuration::new(1)));
+    /// assert_eq!(CoarseDuration::new(1).checked_div(2), Some(CoarseDuration::new(0)));
+    /// assert_eq!(CoarseDuration::new(2).checked_div(0), None);
+    /// ```
+    #[inline]
+    pub const fn checked_div(self, rhs: u32) -> Option<Self> {
+        if rhs != 0 {
+            let secs = self.secs / rhs;
+            Some(Self { secs })
+        } else {
+            None
+        }
+    }
+}
+
+impl Add for CoarseDuration {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        self.checked_add(rhs)
+            .expect("overflow when adding durations")
+    }
+}
+
+impl AddAssign for CoarseDuration {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sub for CoarseDuration {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        self.checked_sub(rhs)
+            .expect("overflow when subtracting durations")
+    }
+}
+
+impl SubAssign for CoarseDuration {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl Mul<u32> for CoarseDuration {
+    type Output = Self;
+
+    fn mul(self, rhs: u32) -> Self {
+        self.checked_mul(rhs)
+            .expect("overflow when multiplying duration by scalar")
+    }
+}
+
+impl Mul<CoarseDuration> for u32 {
+    type Output = CoarseDuration;
+
+    fn mul(self, rhs: CoarseDuration) -> CoarseDuration {
+        rhs * self
+    }
+}
+
+impl MulAssign<u32> for CoarseDuration {
+    fn mul_assign(&mut self, rhs: u32) {
+        *self = *self * rhs;
+    }
+}
+
+impl Div<u32> for CoarseDuration {
+    type Output = Self;
+
+    fn div(self, rhs: u32) -> Self {
+        self.checked_div(rhs)
+            .expect("divide by zero error when dividing duration by scalar")
+    }
+}
+
+impl DivAssign<u32> for CoarseDuration {
+    fn div_assign(&mut self, rhs: u32) {
+        *self = *self / rhs;
+    }
+}
+
+macro_rules! sum_durations {
+    ($iter:expr) => {{
+        let mut secs: u32 = 0;
+
+        for entry in $iter {
+            secs = secs
+                .checked_add(entry.secs)
+                .expect("overflow in iter::sum over durations");
+        }
+        CoarseDuration { secs }
+    }};
+}
+
+impl Sum for CoarseDuration {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        sum_durations!(iter)
+    }
+}
+
+impl<'a> Sum<&'a Self> for CoarseDuration {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        sum_durations!(iter)
+    }
+}
+
+impl fmt::Debug for CoarseDuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}s", self.secs)
+    }
+}

--- a/time/src/duration/mod.rs
+++ b/time/src/duration/mod.rs
@@ -1,0 +1,5 @@
+mod coarse;
+mod precise;
+
+pub use coarse::*;
+pub use precise::*;

--- a/time/src/duration/precise/atomic.rs
+++ b/time/src/duration/precise/atomic.rs
@@ -1,0 +1,344 @@
+use crate::*;
+
+/// An `AtomicDuration` is an atomic equivalent of [`Duration`].
+///
+/// # Examples
+///
+/// ```
+/// use rustcommon_time::AtomicDuration;
+/// use core::sync::atomic::Ordering;
+///
+/// let duration = AtomicDuration::new(5, 5);
+/// assert_eq!(duration.load(Ordering::Relaxed).as_secs(), 5);
+/// assert_eq!(duration.load(Ordering::Relaxed).subsec_nanos(), 5);
+///
+/// let ten_millis = AtomicDuration::from_millis(10);
+/// ```
+pub struct AtomicDuration {
+    nanos: AtomicU64,
+}
+
+impl AtomicDuration {
+    /// Creates a new `Duration` from the specified number of whole seconds and
+    /// additional nanoseconds.
+    ///
+    /// If the number of nanoseconds is greater than 1 billion (the number of
+    /// nanoseconds in a second), then it will carry over into the seconds
+    /// provided.
+    ///
+    /// # Panics
+    ///
+    /// This constructor will panic if the carry from the nanoseconds overflows
+    /// the seconds counter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let five_seconds = Duration::new(5, 0);
+    /// ```
+    #[inline]
+    pub fn new(secs: u64, nanos: u32) -> Self {
+        let secs_ns = secs
+            .checked_mul(NANOS_PER_SEC)
+            .expect("number of seconds caused overflow");
+        let nanos = secs_ns
+            .checked_add(nanos as u64)
+            .expect("total duration caused overflow");
+        Self {
+            nanos: AtomicU64::new(nanos),
+        }
+    }
+
+    /// Creates a new `AtomicDuration` from the specified number of whole seconds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = Duration::from_secs(5);
+    ///
+    /// assert_eq!(5, duration.as_secs());
+    /// assert_eq!(0, duration.subsec_nanos());
+    /// ```
+    #[inline]
+    pub fn from_secs(secs: u64) -> Self {
+        let nanos = secs
+            .checked_mul(NANOS_PER_SEC)
+            .expect("total duration caused overflow");
+        Self {
+            nanos: AtomicU64::new(nanos),
+        }
+    }
+
+    /// Creates a new `AtomicDuration` from the specified number of milliseconds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::AtomicDuration;
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicDuration::from_millis(2569);
+    ///
+    /// assert_eq!(2, duration.load(Ordering::Relaxed).as_secs());
+    /// assert_eq!(569_000_000, duration.load(Ordering::Relaxed).subsec_nanos());
+    /// ```
+    #[inline]
+    pub fn from_millis(millis: u64) -> Self {
+        let nanos = millis
+            .checked_mul(NANOS_PER_MILLI)
+            .expect("total duration caused overflow");
+        Self {
+            nanos: AtomicU64::new(nanos),
+        }
+    }
+
+    /// Creates a new `AtomicDuration` from the specified number of microseconds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::AtomicDuration;
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicDuration::from_micros(1_000_002);
+    ///
+    /// assert_eq!(1, duration.load(Ordering::Relaxed).as_secs());
+    /// assert_eq!(2000, duration.load(Ordering::Relaxed).subsec_nanos());
+    /// ```
+    #[inline]
+    pub fn from_micros(micros: u64) -> Self {
+        let nanos = micros
+            .checked_mul(NANOS_PER_MICRO)
+            .expect("total duration caused overflow");
+        Self {
+            nanos: AtomicU64::new(nanos),
+        }
+    }
+
+    /// Creates a new `AtomicDuration` from the specified number of nanoseconds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::AtomicDuration;
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicDuration::from_nanos(1_000_000_123);
+    ///
+    /// assert_eq!(1, duration.load(Ordering::Relaxed).as_secs());
+    /// assert_eq!(123, duration.load(Ordering::Relaxed).subsec_nanos());
+    /// ```
+    #[inline]
+    pub const fn from_nanos(nanos: u64) -> Self {
+        Self {
+            nanos: AtomicU64::new(nanos),
+        }
+    }
+
+    /// Consumes the atomic and returns the contained value.
+    ///
+    /// This is safe because passing `self` by value guarantees that no other
+    /// threads are concurrently accessing the atomic data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicDuration, Duration};
+    ///
+    /// let duration = AtomicDuration::from_nanos(1337);
+    /// assert_eq!(duration.into_inner(), Duration::from_nanos(1337));
+    /// ```
+    pub fn into_inner(self) -> Duration {
+        Duration {
+            nanos: self.nanos.into_inner(),
+        }
+    }
+
+    /// Loads the duration from the atomic duration.
+    ///
+    /// `load` takes an `Ordering` argument which describes the memory ordering
+    /// of this operation. Possible values are `SeqCst`, `Acquire`, and
+    /// `Relaxed`.
+    ///
+    /// # Panics
+    /// Panics if `order` is `Release` or `AcqRel`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicDuration, Duration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicDuration::from_secs(5);
+    /// assert_eq!(duration.load(Ordering::Relaxed), Duration::from_secs(5));
+    /// ```
+    pub fn load(&self, order: Ordering) -> Duration {
+        Duration {
+            nanos: self.nanos.load(order),
+        }
+    }
+
+    /// Stores the duration into the atomic duration.
+    ///
+    /// `store` takes an `Ordering` argument which describes the memory ordering
+    /// of this operation. Possible values are `SeqCst`, `Release`, and
+    /// `Relaxed`.
+    ///
+    /// # Panics
+    /// Panics if `order` is `Acquire` or `AcqRel`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicDuration, Duration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicDuration::from_secs(5);
+    ///
+    /// duration.store(Duration::from_secs(10), Ordering::Relaxed);
+    /// assert_eq!(duration.load(Ordering::Relaxed), Duration::from_secs(10));
+    /// ```
+    pub fn store(&self, val: Duration, order: Ordering) {
+        self.nanos.store(val.nanos, order)
+    }
+
+    /// Stores the duration into the atomic duration, returning the previous
+    /// value.
+    ///
+    /// `swap` takes an `Ordering` argument which describes the memory ordering
+    /// of this operation. All ordering modes are possible. Note that using
+    /// `Acquire` makes the store part of this operation `Relaxed`, and using
+    /// `Release` makes the load part `Relaxed`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicDuration, Duration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicDuration::from_secs(5);
+    ///
+    /// assert_eq!(duration.swap(Duration::from_secs(10), Ordering::Relaxed), Duration::from_secs(5));
+    /// ```
+    pub fn swap(&self, val: Duration, order: Ordering) -> Duration {
+        Duration {
+            nanos: self.nanos.swap(val.nanos, order),
+        }
+    }
+
+    /// Stores the duration into the atomic duration if the current value is the
+    /// same as the `current` value.
+    ///
+    /// The return value is a result indicating whether the new value was
+    /// written and containing the previous value. On success this value is
+    /// guaranteed to be equal to current.
+    ///
+    /// `compare_exchange` takes two `Ordering` arguments to describe the memory
+    /// ordering of this operation. `success` describes the required ordering
+    /// for the read-modify-write operation that takes place if the comparison
+    /// with `current` succeeds. `failure` describes the required ordering for
+    /// the load operation that takes place when the comparison fails. Using
+    /// `Acquire` as success ordering makes the store part of this operation
+    /// `Relaxed`, and using `Release makes the successful load `Relaxed`. The
+    /// failure ordering can only be, `SeqCst`, `Acquire`, or `Relaxed` and must
+    /// be equivalent to or weaker than the success ordering.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicDuration, Duration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicDuration::from_secs(5);
+    ///
+    /// assert_eq!(duration.compare_exchange(
+    ///     Duration::from_secs(5),
+    ///     Duration::from_secs(10),
+    ///     Ordering::Acquire,
+    ///     Ordering::Relaxed),
+    ///     Ok(Duration::from_secs(5)));
+    /// assert_eq!(duration.load(Ordering::Relaxed), Duration::from_secs(10));
+    ///
+    /// assert_eq!(duration.compare_exchange(
+    ///     Duration::from_secs(6),
+    ///     Duration::from_secs(12),
+    ///     Ordering::Acquire,
+    ///     Ordering::Relaxed),
+    ///     Err(Duration::from_secs(10)));
+    /// assert_eq!(duration.load(Ordering::Relaxed), Duration::from_secs(10));
+    ///
+    /// ```
+    pub fn compare_exchange(
+        &self,
+        current: Duration,
+        new: Duration,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Duration, Duration> {
+        match self
+            .nanos
+            .compare_exchange(current.nanos, new.nanos, success, failure)
+        {
+            Ok(nanos) => Ok(Duration { nanos }),
+            Err(nanos) => Err(Duration { nanos }),
+        }
+    }
+
+    /// Stores the duration into the atomic duration if the current value is the
+    /// same as the `current` value.
+    ///
+    /// Unlike `AtomicDuration::compare_exchange`, this function is allowed to
+    /// spuriously fail even when the comparison succeeds, which can result in
+    /// more efficient code on some platforms. The return value is a result
+    /// indicating whether the new value was written and containing the previous
+    /// value.
+    ///
+    /// `compare_exchange_weak` takes two `Ordering` arguments to describe the
+    /// memory ordering of this operation. `success` describes the required
+    /// ordering for the read-modify-write operation that takes place if the
+    /// comparison with `current` succeeds. `failure` describes the required
+    /// ordering for the load operation that takes place when the comparison
+    /// fails. Using `Acquire` as success ordering makes the store part of this
+    /// operation `Relaxed`, and using `Release makes the successful load
+    /// `Relaxed`. The failure ordering can only be, `SeqCst`, `Acquire`, or
+    /// `Relaxed` and must be equivalent to or weaker than the success ordering.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicDuration, Duration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let duration = AtomicDuration::from_secs(5);
+    ///
+    /// let mut old = duration.load(Ordering::Relaxed);
+    /// loop {
+    ///     let new = old.saturating_mul(2);
+    ///     match duration.compare_exchange_weak(old, new, Ordering::SeqCst, Ordering::Relaxed) {
+    ///         Ok(_) => break,
+    ///         Err(x) => old = x,
+    ///     }
+    /// }
+    /// ```
+    pub fn compare_exchange_weak(
+        &self,
+        current: Duration,
+        new: Duration,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Duration, Duration> {
+        match self
+            .nanos
+            .compare_exchange_weak(current.nanos, new.nanos, success, failure)
+        {
+            Ok(nanos) => Ok(Duration { nanos }),
+            Err(nanos) => Err(Duration { nanos }),
+        }
+    }
+}

--- a/time/src/duration/precise/mod.rs
+++ b/time/src/duration/precise/mod.rs
@@ -1,0 +1,5 @@
+mod atomic;
+mod plain;
+
+pub use atomic::*;
+pub use plain::*;

--- a/time/src/duration/precise/plain.rs
+++ b/time/src/duration/precise/plain.rs
@@ -1,0 +1,972 @@
+//! Temporal quantification.
+//!
+//! Example:
+//!
+//! ```
+//! use rustcommon_time::Duration;
+//!
+//! let five_seconds = Duration::new(5, 0);
+//! // both declarations are equivalent
+//! assert_eq!(Duration::new(5, 0), Duration::from_secs(5));
+//! ```
+
+use core::fmt;
+use core::iter::Sum;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
+use crate::*;
+
+/// A `Duration` type to represent a span of time, typically used for system
+/// timeouts.
+///
+/// Each `Duration` is composed of a whole number of seconds and a fractional part
+/// represented in nanoseconds. If the underlying system does not support
+/// nanosecond-level precision, APIs binding a system timeout will typically round up
+/// the number of nanoseconds.
+///
+/// [`Duration`]s implement many common traits, including [`Add`], [`Sub`], and other
+/// [`ops`] traits. It implements [`Default`] by returning a zero-length `Duration`.
+///
+/// [`ops`]: core::ops
+///
+/// # Examples
+///
+/// ```
+/// use rustcommon_time::Duration;
+///
+/// let five_seconds = Duration::new(5, 0);
+/// let five_seconds_and_five_nanos = five_seconds + Duration::new(0, 5);
+///
+/// assert_eq!(five_seconds_and_five_nanos.as_secs(), 5);
+/// assert_eq!(five_seconds_and_five_nanos.subsec_nanos(), 5);
+///
+/// let ten_millis = Duration::from_millis(10);
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Duration {
+    pub(crate) nanos: u64,
+}
+
+impl Duration {
+    /// The duration of one second.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::SECOND, Duration::from_secs(1));
+    /// ```
+    pub const SECOND: Duration = Duration::from_nanos(NANOS_PER_SEC);
+
+    /// The duration of one millisecond.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::MILLISECOND, Duration::from_millis(1));
+    /// ```
+    pub const MILLISECOND: Duration = Duration::from_nanos(NANOS_PER_MILLI);
+
+    /// The duration of one microsecond.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::MICROSECOND, Duration::from_micros(1));
+    /// ```
+    pub const MICROSECOND: Duration = Duration::from_nanos(NANOS_PER_MICRO);
+
+    /// The duration of one nanosecond.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::NANOSECOND, Duration::from_nanos(1));
+    /// ```
+    pub const NANOSECOND: Duration = Duration::from_nanos(1);
+
+    /// A duration of zero time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::ZERO;
+    /// assert!(duration.is_zero());
+    /// assert_eq!(duration.as_nanos(), 0);
+    /// ```
+    pub const ZERO: Duration = Duration::from_nanos(0);
+
+    /// The maximum duration.
+    ///
+    /// It is roughly equal to a duration of 584.942 years.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::MAX, Duration::from_nanos(u64::MAX));
+    /// ```
+    pub const MAX: Duration = Duration::from_nanos(u64::MAX);
+
+    /// Creates a new `Duration` from the specified number of whole seconds and
+    /// additional nanoseconds.
+    ///
+    /// If the number of nanoseconds is greater than 1 billion (the number of
+    /// nanoseconds in a second), then it will carry over into the seconds
+    /// provided.
+    ///
+    /// # Panics
+    ///
+    /// This constructor will panic if the total duration exceeds
+    /// `Duration::MAX`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let five_seconds = Duration::new(5, 0);
+    /// ```
+    #[inline]
+    pub fn new(secs: u64, nanos: u32) -> Duration {
+        let secs_ns = secs
+            .checked_mul(NANOS_PER_SEC)
+            .expect("number of seconds caused overflow");
+        let nanos = secs_ns
+            .checked_add(nanos as u64)
+            .expect("total duration caused overflow");
+        Duration { nanos }
+    }
+
+    /// Creates a new `Duration` from the specified number of whole seconds.
+    ///
+    /// # Panics
+    /// This constructor will panic if `secs` overflows `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::from_secs(5);
+    ///
+    /// assert_eq!(5, duration.as_secs());
+    /// assert_eq!(0, duration.subsec_nanos());
+    /// ```
+    #[inline]
+    pub fn from_secs(secs: u64) -> Duration {
+        let nanos = secs
+            .checked_mul(NANOS_PER_SEC)
+            .expect("total duration caused overflow");
+        Duration { nanos }
+    }
+
+    /// Creates a new `Duration` from the specified number of milliseconds.
+    ///
+    /// # Panics
+    /// This constructor will panic if `millis` overflows `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::from_millis(2569);
+    ///
+    /// assert_eq!(2, duration.as_secs());
+    /// assert_eq!(569_000_000, duration.subsec_nanos());
+    /// ```
+    #[inline]
+    pub fn from_millis(millis: u64) -> Duration {
+        let nanos = millis
+            .checked_mul(NANOS_PER_MILLI)
+            .expect("total duration caused overflow");
+        Duration { nanos }
+    }
+
+    /// Creates a new `Duration` from the specified number of microseconds.
+    ///
+    /// # Panics
+    /// This constructor will panic if `micros` overflows `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::from_micros(1_000_002);
+    ///
+    /// assert_eq!(1, duration.as_secs());
+    /// assert_eq!(2000, duration.subsec_nanos());
+    /// ```
+    #[inline]
+    pub fn from_micros(micros: u64) -> Duration {
+        let nanos = micros
+            .checked_mul(NANOS_PER_MICRO)
+            .expect("total duration caused overflow");
+        Duration { nanos }
+    }
+
+    /// Creates a new `Duration` from the specified number of nanoseconds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::from_nanos(1_000_000_123);
+    ///
+    /// assert_eq!(1, duration.as_secs());
+    /// assert_eq!(123, duration.subsec_nanos());
+    /// ```
+    #[inline]
+    pub const fn from_nanos(nanos: u64) -> Duration {
+        Duration { nanos }
+    }
+
+    /// Returns true if this `Duration` spans no time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert!(Duration::ZERO.is_zero());
+    /// assert!(Duration::new(0, 0).is_zero());
+    /// assert!(Duration::from_nanos(0).is_zero());
+    /// assert!(Duration::from_secs(0).is_zero());
+    ///
+    /// assert!(!Duration::new(1, 1).is_zero());
+    /// assert!(!Duration::from_nanos(1).is_zero());
+    /// assert!(!Duration::from_secs(1).is_zero());
+    /// ```
+    #[inline]
+    pub const fn is_zero(&self) -> bool {
+        self.nanos == 0
+    }
+
+    /// Returns the number of _whole_ seconds contained by this `Duration`.
+    ///
+    /// The returned value does not include the fractional (nanosecond) part of
+    /// the duration, which can be obtained using [`subsec_nanos`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    /// assert_eq!(duration.as_secs(), 5);
+    /// ```
+    ///
+    /// To determine the total number of seconds represented by the `Duration`,
+    /// use `as_secs` in combination with [`subsec_nanos`]:
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    ///
+    /// assert_eq!(5.730023852,
+    ///            duration.as_secs() as f64
+    ///            + duration.subsec_nanos() as f64 * 1e-9);
+    /// ```
+    ///
+    /// [`subsec_nanos`]: Duration::subsec_nanos
+    #[inline]
+    pub const fn as_secs(&self) -> u64 {
+        self.nanos / NANOS_PER_SEC
+    }
+
+    /// Returns the fractional part of this `Duration`, in whole milliseconds.
+    ///
+    /// This method does **not** return the length of the duration when
+    /// represented by milliseconds. The returned number always represents a
+    /// fractional portion of a second (i.e., it is less than one thousand).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::from_millis(5432);
+    /// assert_eq!(duration.as_secs(), 5);
+    /// assert_eq!(duration.subsec_millis(), 432);
+    /// ```
+    #[inline]
+    pub const fn subsec_millis(&self) -> u32 {
+        ((self.nanos % NANOS_PER_SEC) / NANOS_PER_MILLI) as u32
+    }
+
+    /// Returns the fractional part of this `Duration`, in whole microseconds.
+    ///
+    /// This method does **not** return the length of the duration when
+    /// represented by microseconds. The returned number always represents a
+    /// fractional portion of a second (i.e., it is less than one million).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::from_micros(1_234_567);
+    /// assert_eq!(duration.as_secs(), 1);
+    /// assert_eq!(duration.subsec_micros(), 234_567);
+    /// ```
+    #[inline]
+    pub const fn subsec_micros(&self) -> u32 {
+        ((self.nanos % NANOS_PER_SEC) / NANOS_PER_MICRO) as u32
+    }
+
+    /// Returns the fractional part of this `Duration`, in nanoseconds.
+    ///
+    /// This method does **not** return the length of the duration when
+    /// represented by nanoseconds. The returned number always represents a
+    /// fractional portion of a second (i.e., it is less than one billion).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::from_millis(5010);
+    /// assert_eq!(duration.as_secs(), 5);
+    /// assert_eq!(duration.subsec_nanos(), 10_000_000);
+    /// ```
+    #[inline]
+    pub const fn subsec_nanos(&self) -> u32 {
+        (self.nanos % NANOS_PER_SEC) as u32
+    }
+
+    /// Returns the total number of whole milliseconds contained by this
+    /// `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    /// assert_eq!(duration.as_millis(), 5730);
+    /// ```
+    #[inline]
+    pub const fn as_millis(&self) -> u128 {
+        (self.nanos / NANOS_PER_MILLI) as u128
+    }
+
+    /// Returns the total number of whole microseconds contained by this
+    /// `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    /// assert_eq!(duration.as_micros(), 5730023);
+    /// ```
+    #[inline]
+    pub const fn as_micros(&self) -> u128 {
+        (self.nanos / NANOS_PER_MICRO) as u128
+    }
+
+    /// Returns the total number of nanoseconds contained by this `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let duration = Duration::new(5, 730023852);
+    /// assert_eq!(duration.as_nanos(), 5730023852);
+    /// ```
+    #[inline]
+    pub const fn as_nanos(&self) -> u128 {
+        self.nanos as u128
+    }
+
+    /// Checked `Duration` addition. Computes `self + other`, returning [`None`]
+    /// if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::new(0, 0).checked_add(Duration::new(0, 1)), Some(Duration::new(0, 1)));
+    /// assert_eq!(Duration::new(1, 0).checked_add(Duration::new(u64::MAX / 1_000_000_000, 0)), None);
+    /// ```
+    #[inline]
+    pub const fn checked_add(self, rhs: Duration) -> Option<Duration> {
+        if let Some(nanos) = self.nanos.checked_add(rhs.nanos) {
+            Some(Duration { nanos })
+        } else {
+            None
+        }
+    }
+
+    /// Saturating `Duration` addition. Computes `self + other`, returning
+    /// [`Duration::MAX`] if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::new(0, 0).saturating_add(Duration::new(0, 1)), Duration::new(0, 1));
+    /// assert_eq!(Duration::new(1, 0).saturating_add(Duration::new(u64::MAX / 1_000_000_000, 0)), Duration::MAX);
+    /// ```
+    #[inline]
+    pub const fn saturating_add(self, rhs: Duration) -> Duration {
+        match self.checked_add(rhs) {
+            Some(res) => res,
+            None => Duration::MAX,
+        }
+    }
+
+    /// Checked `Duration` subtraction. Computes `self - other`, returning
+    /// [`None`] if the result would be negative or if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::new(0, 1).checked_sub(Duration::new(0, 0)), Some(Duration::new(0, 1)));
+    /// assert_eq!(Duration::new(0, 0).checked_sub(Duration::new(0, 1)), None);
+    /// ```
+    #[inline]
+    pub const fn checked_sub(self, rhs: Duration) -> Option<Duration> {
+        if let Some(nanos) = self.nanos.checked_sub(rhs.nanos) {
+            Some(Duration { nanos })
+        } else {
+            None
+        }
+    }
+
+    /// Saturating `Duration` subtraction. Computes `self - other`, returning
+    /// [`Duration::ZERO`] if the result would be negative or if overflow
+    /// occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::new(0, 1).saturating_sub(Duration::new(0, 0)), Duration::new(0, 1));
+    /// assert_eq!(Duration::new(0, 0).saturating_sub(Duration::new(0, 1)), Duration::ZERO);
+    /// ```
+    #[inline]
+    pub const fn saturating_sub(self, rhs: Duration) -> Duration {
+        match self.checked_sub(rhs) {
+            Some(res) => res,
+            None => Duration::ZERO,
+        }
+    }
+
+    /// Checked `Duration` multiplication. Computes `self * other`, returning
+    /// [`None`] if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::new(0, 500_000_001).checked_mul(2), Some(Duration::new(1, 2)));
+    /// assert_eq!(Duration::new(u64::MAX / 1_000_000_000, 0).checked_mul(2), None);
+    /// ```
+    #[inline]
+    pub const fn checked_mul(self, rhs: u32) -> Option<Duration> {
+        if let Some(nanos) = self.nanos.checked_mul(rhs as u64) {
+            Some(Duration { nanos })
+        } else {
+            None
+        }
+    }
+
+    /// Saturating `Duration` multiplication. Computes `self * other`, returning
+    /// [`Duration::MAX`] if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::new(0, 500_000_001).saturating_mul(2), Duration::new(1, 2));
+    /// assert_eq!(Duration::new(u64::MAX / 1_000_000_000, 0).saturating_mul(2), Duration::MAX);
+    /// ```
+    #[inline]
+    pub const fn saturating_mul(self, rhs: u32) -> Duration {
+        match self.checked_mul(rhs) {
+            Some(res) => res,
+            None => Duration::MAX,
+        }
+    }
+
+    /// Checked `Duration` division. Computes `self / other`, returning [`None`]
+    /// if `other == 0`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// assert_eq!(Duration::new(2, 0).checked_div(2), Some(Duration::new(1, 0)));
+    /// assert_eq!(Duration::new(1, 0).checked_div(2), Some(Duration::new(0, 500_000_000)));
+    /// assert_eq!(Duration::new(2, 0).checked_div(0), None);
+    /// ```
+    #[inline]
+    pub const fn checked_div(self, rhs: u32) -> Option<Duration> {
+        if rhs != 0 {
+            let nanos = self.nanos / rhs as u64;
+            Some(Duration { nanos })
+        } else {
+            None
+        }
+    }
+
+    /// Returns the number of seconds contained by this `Duration` as `f64`.
+    ///
+    /// The returned value does include the fractional (nanosecond) part of the
+    /// duration.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let dur = Duration::new(2, 700_000_000);
+    /// assert_eq!(dur.as_secs_f64(), 2.7);
+    /// ```
+    #[inline]
+    pub fn as_secs_f64(&self) -> f64 {
+        (self.nanos as f64) / (NANOS_PER_SEC as f64)
+    }
+
+    /// Returns the number of seconds contained by this `Duration` as `f32`.
+    ///
+    /// The returned value does include the fractional (nanosecond) part of the
+    /// duration.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let dur = Duration::new(2, 700_000_000);
+    /// assert_eq!(dur.as_secs_f32(), 2.7);
+    /// ```
+    #[inline]
+    pub fn as_secs_f32(&self) -> f32 {
+        (self.nanos as f32) / (NANOS_PER_SEC as f32)
+    }
+
+    /// Creates a new `Duration` from the specified number of seconds
+    /// represented as `f64`.
+    ///
+    /// # Panics
+    /// This constructor will panic if `secs` is not finite, negative or
+    /// overflows `Duration`.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let dur = Duration::from_secs_f64(2.7);
+    /// assert_eq!(dur, Duration::new(2, 700_000_000));
+    /// ```
+    #[inline]
+    pub fn from_secs_f64(secs: f64) -> Duration {
+        let nanos = secs * (NANOS_PER_SEC as f64);
+        if !nanos.is_finite() {
+            panic!("got non-finite value when converting float to duration");
+        }
+        if nanos > u64::MAX as f64 {
+            panic!("overflow when converting float to duration");
+        }
+        if nanos < 0.0 {
+            panic!("underflow when converting float to duration");
+        }
+        Duration {
+            nanos: nanos as u64,
+        }
+    }
+
+    /// Creates a new `Duration` from the specified number of seconds
+    /// represented as `f32`.
+    ///
+    /// # Panics
+    /// This constructor will panic if `secs` is not finite, negative or
+    /// overflows `Duration`.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let dur = Duration::from_secs_f32(2.7);
+    /// assert_eq!(dur, Duration::new(2, 700_000_000));
+    /// ```
+    #[inline]
+    pub fn from_secs_f32(secs: f32) -> Duration {
+        let nanos = secs * (NANOS_PER_SEC as f32);
+        if !nanos.is_finite() {
+            panic!("got non-finite value when converting float to duration");
+        }
+        if nanos > u64::MAX as f32 {
+            panic!("overflow when converting float to duration");
+        }
+        if nanos < 0.0 {
+            panic!("underflow when converting float to duration");
+        }
+        Duration {
+            nanos: nanos as u64,
+        }
+    }
+
+    /// Multiplies `Duration` by `f64`.
+    ///
+    /// # Panics
+    /// This method will panic if result is not finite, negative or overflows
+    /// `Duration`.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let dur = Duration::new(2, 700_000_000);
+    /// assert_eq!(dur.mul_f64(3.14), Duration::new(8, 478_000_000));
+    /// assert_eq!(dur.mul_f64(3.14e5), Duration::new(847_800, 0));
+    /// ```
+    #[inline]
+    pub fn mul_f64(self, rhs: f64) -> Duration {
+        Duration::from_secs_f64(rhs * self.as_secs_f64())
+    }
+
+    /// Multiplies `Duration` by `f32`.
+    ///
+    /// # Panics
+    /// This method will panic if result is not finite, negative or overflows
+    /// `Duration`.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let dur = Duration::new(2, 700_000_000);
+    /// // note that due to rounding errors result is slightly different
+    /// // from 8.478 and 847800.0
+    /// assert_eq!(dur.mul_f32(3.14), Duration::new(8, 478_000_640));
+    /// assert_eq!(dur.mul_f32(3.14e5), Duration::new(847799, 969_120_256));
+    /// ```
+    #[inline]
+    pub fn mul_f32(self, rhs: f32) -> Duration {
+        Duration::from_secs_f32(rhs * self.as_secs_f32())
+    }
+
+    /// Divide `Duration` by `f64`.
+    ///
+    /// # Panics
+    /// This method will panic if result is not finite, negative or overflows
+    /// `Duration`.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let dur = Duration::new(2, 700_000_000);
+    /// assert_eq!(dur.div_f64(3.14), Duration::new(0, 859_872_611));
+    /// // note that truncation is used, not rounding
+    /// assert_eq!(dur.div_f64(3.14e5), Duration::new(0, 8_598));
+    /// ```
+    #[inline]
+    pub fn div_f64(self, rhs: f64) -> Duration {
+        Duration::from_secs_f64(self.as_secs_f64() / rhs)
+    }
+
+    /// Divide `Duration` by `f32`.
+    ///
+    /// # Panics
+    /// This method will panic if result is not finite, negative or overflows
+    /// `Duration`.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let dur = Duration::new(2, 700_000_000);
+    /// // note that due to rounding errors result is slightly
+    /// // different from 0.859_872_611
+    /// assert_eq!(dur.div_f32(3.14), Duration::new(0, 859_872_576));
+    /// // note that truncation is used, not rounding
+    /// assert_eq!(dur.div_f32(3.14e5), Duration::new(0, 8_598));
+    /// ```
+    #[inline]
+    pub fn div_f32(self, rhs: f32) -> Duration {
+        Duration::from_secs_f32(self.as_secs_f32() / rhs)
+    }
+
+    /// Divide `Duration` by `Duration` and return `f64`.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let dur1 = Duration::new(2, 700_000_000);
+    /// let dur2 = Duration::new(5, 400_000_000);
+    /// assert_eq!(dur1.div_duration_f64(dur2), 0.5);
+    /// ```
+    #[inline]
+    pub fn div_duration_f64(self, rhs: Duration) -> f64 {
+        self.as_secs_f64() / rhs.as_secs_f64()
+    }
+
+    /// Divide `Duration` by `Duration` and return `f32`.
+    ///
+    /// # Examples
+    /// ```
+    /// use rustcommon_time::Duration;
+    ///
+    /// let dur1 = Duration::new(2, 700_000_000);
+    /// let dur2 = Duration::new(5, 400_000_000);
+    /// assert_eq!(dur1.div_duration_f32(dur2), 0.5);
+    /// ```
+    #[inline]
+    pub fn div_duration_f32(self, rhs: Duration) -> f32 {
+        self.as_secs_f32() / rhs.as_secs_f32()
+    }
+}
+
+impl Add for Duration {
+    type Output = Duration;
+
+    fn add(self, rhs: Duration) -> Duration {
+        self.checked_add(rhs)
+            .expect("overflow when adding durations")
+    }
+}
+
+impl AddAssign for Duration {
+    fn add_assign(&mut self, rhs: Duration) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sub for Duration {
+    type Output = Duration;
+
+    fn sub(self, rhs: Duration) -> Duration {
+        self.checked_sub(rhs)
+            .expect("overflow when subtracting durations")
+    }
+}
+
+impl SubAssign for Duration {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = *self - rhs;
+    }
+}
+
+impl Mul<u32> for Duration {
+    type Output = Duration;
+
+    fn mul(self, rhs: u32) -> Duration {
+        self.checked_mul(rhs)
+            .expect("overflow when multiplying duration by scalar")
+    }
+}
+
+impl Mul<Duration> for u32 {
+    type Output = Duration;
+
+    fn mul(self, rhs: Duration) -> Duration {
+        rhs * self
+    }
+}
+
+impl MulAssign<u32> for Duration {
+    fn mul_assign(&mut self, rhs: u32) {
+        *self = *self * rhs;
+    }
+}
+
+impl Div<u32> for Duration {
+    type Output = Duration;
+
+    fn div(self, rhs: u32) -> Duration {
+        self.checked_div(rhs)
+            .expect("divide by zero error when dividing duration by scalar")
+    }
+}
+
+impl DivAssign<u32> for Duration {
+    fn div_assign(&mut self, rhs: u32) {
+        *self = *self / rhs;
+    }
+}
+
+macro_rules! sum_durations {
+    ($iter:expr) => {{
+        let mut nanos: u64 = 0;
+
+        for entry in $iter {
+            nanos = nanos
+                .checked_add(entry.nanos as u64)
+                .expect("overflow in iter::sum over durations");
+        }
+        Duration { nanos }
+    }};
+}
+
+impl Sum for Duration {
+    fn sum<I: Iterator<Item = Duration>>(iter: I) -> Duration {
+        sum_durations!(iter)
+    }
+}
+
+impl<'a> Sum<&'a Duration> for Duration {
+    fn sum<I: Iterator<Item = &'a Duration>>(iter: I) -> Duration {
+        sum_durations!(iter)
+    }
+}
+
+impl fmt::Debug for Duration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        /// Formats a floating point number in decimal notation.
+        ///
+        /// The number is given as the `integer_part` and a fractional part.
+        /// The value of the fractional part is `fractional_part / divisor`. So
+        /// `integer_part` = 3, `fractional_part` = 12 and `divisor` = 100
+        /// represents the number `3.012`. Trailing zeros are omitted.
+        ///
+        /// `divisor` must not be above 100_000_000. It also should be a power
+        /// of 10, everything else doesn't make sense. `fractional_part` has
+        /// to be less than `10 * divisor`!
+        fn fmt_decimal(
+            f: &mut fmt::Formatter<'_>,
+            mut integer_part: u64,
+            mut fractional_part: u64,
+            mut divisor: u64,
+        ) -> fmt::Result {
+            // Encode the fractional part into a temporary buffer. The buffer
+            // only need to hold 9 elements, because `fractional_part` has to
+            // be smaller than 10^9. The buffer is prefilled with '0' digits
+            // to simplify the code below.
+            let mut buf = [b'0'; 9];
+
+            // The next digit is written at this position
+            let mut pos = 0;
+
+            // We keep writing digits into the buffer while there are non-zero
+            // digits left and we haven't written enough digits yet.
+            while fractional_part > 0 && pos < f.precision().unwrap_or(9) {
+                // Write new digit into the buffer
+                buf[pos] = b'0' + (fractional_part / divisor) as u8;
+
+                fractional_part %= divisor;
+                divisor /= 10;
+                pos += 1;
+            }
+
+            // If a precision < 9 was specified, there may be some non-zero
+            // digits left that weren't written into the buffer. In that case we
+            // need to perform rounding to match the semantics of printing
+            // normal floating point numbers. However, we only need to do work
+            // when rounding up. This happens if the first digit of the
+            // remaining ones is >= 5.
+            if fractional_part > 0 && fractional_part >= divisor * 5 {
+                // Round up the number contained in the buffer. We go through
+                // the buffer backwards and keep track of the carry.
+                let mut rev_pos = pos;
+                let mut carry = true;
+                while carry && rev_pos > 0 {
+                    rev_pos -= 1;
+
+                    // If the digit in the buffer is not '9', we just need to
+                    // increment it and can stop then (since we don't have a
+                    // carry anymore). Otherwise, we set it to '0' (overflow)
+                    // and continue.
+                    if buf[rev_pos] < b'9' {
+                        buf[rev_pos] += 1;
+                        carry = false;
+                    } else {
+                        buf[rev_pos] = b'0';
+                    }
+                }
+
+                // If we still have the carry bit set, that means that we set
+                // the whole buffer to '0's and need to increment the integer
+                // part.
+                if carry {
+                    integer_part += 1;
+                }
+            }
+
+            // Determine the end of the buffer: if precision is set, we just
+            // use as many digits from the buffer (capped to 9). If it isn't
+            // set, we only use all digits up to the last non-zero one.
+            let end = f.precision().map(|p| core::cmp::min(p, 9)).unwrap_or(pos);
+
+            // If we haven't emitted a single fractional digit and the precision
+            // wasn't set to a non-zero value, we don't print the decimal point.
+            if end == 0 {
+                write!(f, "{}", integer_part)
+            } else {
+                // SAFETY: We are only writing ASCII digits into the buffer and
+                // it was initialized with '0's, so it contains valid UTF8.
+                let s = unsafe { core::str::from_utf8_unchecked(&buf[..end]) };
+
+                // If the user request a precision > 9, we pad '0's at the end.
+                let w = f.precision().unwrap_or(pos);
+                write!(f, "{}.{:0<width$}", integer_part, s, width = w)
+            }
+        }
+
+        // Print leading '+' sign if requested
+        if f.sign_plus() {
+            write!(f, "+")?;
+        }
+
+        let secs = self.nanos / NANOS_PER_SEC;
+        let nanos = self.nanos % NANOS_PER_SEC;
+
+        if secs > 0 {
+            fmt_decimal(f, secs, nanos, NANOS_PER_SEC / 10)?;
+            f.write_str("s")
+        } else if nanos >= NANOS_PER_MILLI {
+            fmt_decimal(
+                f,
+                (nanos / NANOS_PER_MILLI) as u64,
+                nanos % NANOS_PER_MILLI,
+                NANOS_PER_MILLI / 10,
+            )?;
+            f.write_str("ms")
+        } else if nanos >= NANOS_PER_MICRO {
+            fmt_decimal(
+                f,
+                (nanos / NANOS_PER_MICRO) as u64,
+                nanos % NANOS_PER_MICRO,
+                NANOS_PER_MICRO / 10,
+            )?;
+            f.write_str("µs")
+        } else {
+            fmt_decimal(f, self.nanos as u64, 0, 1)?;
+            f.write_str("ns")
+        }
+    }
+}

--- a/time/src/instant/coarse/mod.rs
+++ b/time/src/instant/coarse/mod.rs
@@ -1,0 +1,61 @@
+use crate::*;
+
+use core::sync::atomic::AtomicU32;
+use core::sync::atomic::Ordering;
+
+mod plain;
+
+pub use plain::*;
+
+/// `AtomicCoarseInstant` is an opaque type that represents a moment in time to
+/// the nearest second. Unlike `CoarseInstant`, it is thread-safe.
+#[derive(Debug)]
+pub struct AtomicCoarseInstant {
+    pub(crate) secs: AtomicU32, // This is enough for >100 years without overflow
+}
+
+impl AtomicCoarseInstant {
+    pub fn now() -> Self {
+        let instant = CoarseInstant::now();
+        Self {
+            secs: AtomicU32::new(instant.secs),
+        }
+    }
+
+    pub fn recent() -> Self {
+        let instant = _clock().recent_coarse();
+        Self {
+            secs: AtomicU32::new(instant.secs),
+        }
+    }
+
+    pub fn load(&self, ordering: Ordering) -> CoarseInstant {
+        CoarseInstant {
+            secs: self.secs.load(ordering),
+        }
+    }
+
+    pub fn store(&self, value: CoarseInstant, ordering: Ordering) {
+        self.secs.store(value.secs, ordering)
+    }
+
+    pub fn fetch_add(&self, other: CoarseDuration, ordering: Ordering) -> CoarseInstant {
+        CoarseInstant {
+            secs: self.secs.fetch_add(other.secs, ordering),
+        }
+    }
+
+    pub fn fetch_sub(&self, other: CoarseDuration, ordering: Ordering) -> CoarseInstant {
+        CoarseInstant {
+            secs: self.secs.fetch_sub(other.secs, ordering),
+        }
+    }
+
+    pub fn refresh(&self, ordering: Ordering) {
+        self.store(CoarseInstant::now(), ordering)
+    }
+
+    pub fn elapsed(&self, ordering: Ordering) -> CoarseDuration {
+        self.load(ordering).elapsed()
+    }
+}

--- a/time/src/instant/coarse/plain.rs
+++ b/time/src/instant/coarse/plain.rs
@@ -1,0 +1,225 @@
+#![allow(clippy::needless_doctest_main)]
+
+use crate::*;
+
+use core::fmt;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+
+/// A lower precision measurement of a monotonically nondecreasing clock. Opaque
+/// and useful only with `CoarseDuration`.
+///
+/// Unlike `Instant`, `CoarseInstant` uses only 32 bits to represent a
+/// measurement from an underlying clock and retains only secondly precision.
+///
+/// This type is most useful for purposes like object expiration, where finer
+/// resolution is not required.
+///
+/// Example:
+///
+/// ```no_run
+/// use rustcommon_time::{CoarseInstant};
+/// use std::thread::sleep;
+///
+/// fn main() {
+///    let now = CoarseInstant::now();
+///
+///    // we sleep for 2 seconds
+///    sleep(core::time::Duration::new(2, 0));
+///    // it prints '2'
+///    println!("{}", now.elapsed().as_secs());
+/// }
+/// ```
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CoarseInstant {
+    pub(crate) secs: u32,
+}
+
+impl CoarseInstant {
+    /// Returns an instant corresponding to "now".
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseInstant;
+    ///
+    /// let now = CoarseInstant::now();
+    /// ```
+    pub fn now() -> CoarseInstant {
+        let precise = Instant::now();
+        Self {
+            secs: (precise.nanos / NANOS_PER_SEC) as u32,
+        }
+    }
+
+    /// Returns an instant corresponding to when
+    /// `rustcommon_time::clock_refresh` was last called.
+    ///
+    /// This is useful for when the overhead of measuring the current instant is
+    /// too high and an approximate measurement is acceptable. Typically the
+    /// clock would be refreshed by a separate thread or outside of any critical
+    /// path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::CoarseInstant;
+    ///
+    /// let now = CoarseInstant::now();
+    /// ```
+    pub fn recent() -> CoarseInstant {
+        _clock().recent_coarse()
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `earlier` is later than `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rustcommon_time::CoarseInstant;
+    /// use std::thread::sleep;
+    ///
+    /// let now = CoarseInstant::now();
+    /// sleep(core::time::Duration::new(1, 0));
+    /// let new_now = CoarseInstant::now();
+    /// println!("{:?}", new_now.duration_since(now));
+    /// ```
+    pub fn duration_since(&self, earlier: CoarseInstant) -> CoarseDuration {
+        let secs = self
+            .secs
+            .checked_sub(earlier.secs)
+            .expect("supplied instant is later than self");
+        CoarseDuration { secs }
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or None if that instant is later than this one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rustcommon_time::CoarseInstant;
+    /// use std::thread::sleep;
+    ///
+    /// let now = CoarseInstant::now();
+    /// sleep(core::time::Duration::new(1, 0));
+    /// let new_now = CoarseInstant::now();
+    /// println!("{:?}", new_now.checked_duration_since(now));
+    /// println!("{:?}", now.checked_duration_since(new_now)); // None
+    /// ```
+    pub fn checked_duration_since(&self, earlier: CoarseInstant) -> Option<CoarseDuration> {
+        let secs = self.secs.checked_sub(earlier.secs)?;
+        Some(CoarseDuration { secs })
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or zero duration if that instant is later than this one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rustcommon_time::CoarseInstant;
+    /// use std::thread::sleep;
+    ///
+    /// let now = CoarseInstant::now();
+    /// sleep(core::time::Duration::new(1, 0));
+    /// let new_now = CoarseInstant::now();
+    /// println!("{:?}", new_now.saturating_duration_since(now));
+    /// println!("{:?}", now.saturating_duration_since(new_now)); // 0s
+    /// ```
+    pub fn saturating_duration_since(&self, earlier: CoarseInstant) -> CoarseDuration {
+        let secs = self.secs.saturating_sub(earlier.secs);
+        CoarseDuration { secs }
+    }
+
+    /// Returns the amount of time elapsed since this instant was created.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if the current time is earlier than this
+    /// instant, which is something that can happen if an `CoarseInstant` is
+    /// produced synthetically.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::thread::sleep;
+    /// use rustcommon_time::{CoarseDuration, CoarseInstant};
+    ///
+    /// let instant = CoarseInstant::now();
+    /// sleep(core::time::Duration::from_secs(3));
+    /// assert!(instant.elapsed() >= CoarseDuration::from_secs(3));
+    /// ```
+    pub fn elapsed(&self) -> CoarseDuration {
+        CoarseInstant::now() - *self
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
+    /// `CoarseInstant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    pub fn checked_add(&self, duration: CoarseDuration) -> Option<CoarseInstant> {
+        let secs = self.secs.checked_add(duration.secs)?;
+        Some(CoarseInstant { secs })
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
+    /// `CoarseInstant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    pub fn checked_sub(&self, duration: CoarseDuration) -> Option<CoarseInstant> {
+        let secs = self.secs.checked_sub(duration.secs)?;
+        Some(CoarseInstant { secs })
+    }
+}
+
+impl Add<CoarseDuration> for CoarseInstant {
+    type Output = CoarseInstant;
+
+    /// # Panics
+    ///
+    /// This function may panic if the resulting point in time cannot be represented by the
+    /// underlying data structure. See [`CoarseInstant::checked_add`] for a version without panic.
+    fn add(self, other: CoarseDuration) -> CoarseInstant {
+        self.checked_add(other)
+            .expect("overflow when adding duration to instant")
+    }
+}
+
+impl AddAssign<CoarseDuration> for CoarseInstant {
+    fn add_assign(&mut self, other: CoarseDuration) {
+        *self = *self + other;
+    }
+}
+
+impl Sub<CoarseDuration> for CoarseInstant {
+    type Output = CoarseInstant;
+
+    fn sub(self, other: CoarseDuration) -> CoarseInstant {
+        self.checked_sub(other)
+            .expect("overflow when subtracting duration from instant")
+    }
+}
+
+impl SubAssign<CoarseDuration> for CoarseInstant {
+    fn sub_assign(&mut self, other: CoarseDuration) {
+        *self = *self - other;
+    }
+}
+
+impl Sub<CoarseInstant> for CoarseInstant {
+    type Output = CoarseDuration;
+
+    fn sub(self, other: CoarseInstant) -> CoarseDuration {
+        self.duration_since(other)
+    }
+}
+
+impl fmt::Debug for CoarseInstant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CoarseInstant")
+            .field("secs", &self.secs)
+            .finish()
+    }
+}

--- a/time/src/instant/mod.rs
+++ b/time/src/instant/mod.rs
@@ -1,0 +1,5 @@
+mod coarse;
+mod precise;
+
+pub use coarse::*;
+pub use precise::*;

--- a/time/src/instant/precise/atomic.rs
+++ b/time/src/instant/precise/atomic.rs
@@ -1,0 +1,268 @@
+use crate::*;
+
+use core::sync::atomic::AtomicU64;
+use core::sync::atomic::Ordering;
+
+/// An `AtomicDuration` is an atomic equivalent of [`Instant`].
+///
+/// # Examples
+///
+/// ```
+/// use rustcommon_time::{AtomicInstant, Duration};
+/// use core::sync::atomic::Ordering;
+///
+/// let now = AtomicInstant::now();
+/// std::thread::sleep(core::time::Duration::from_secs(1));
+/// assert!(now.load(Ordering::Relaxed).elapsed() >= Duration::from_secs(1));
+/// ```
+pub struct AtomicInstant {
+    pub(crate) nanos: AtomicU64,
+}
+
+impl AtomicInstant {
+    /// Returns an instant corresponding to "now".
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::AtomicInstant;
+    ///
+    /// let now = AtomicInstant::now();
+    /// ```
+    pub fn now() -> Self {
+        let instant = Instant::now();
+        Self {
+            nanos: AtomicU64::new(instant.nanos),
+        }
+    }
+
+    /// Returns an instant corresponding to when
+    /// `rustcommon_time::clock_refresh` was last called.
+    ///
+    /// This is useful for when the overhead of measuring the current instant is
+    /// too high and an approximate measurement is acceptable. Typically the
+    /// clock would be refreshed by a separate thread or outside of any critical
+    /// path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::AtomicInstant;
+    ///
+    /// let recent = AtomicInstant::recent();
+    /// ```
+    pub fn recent() -> Self {
+        let instant = _clock().recent_precise();
+        Self {
+            nanos: AtomicU64::new(instant.nanos),
+        }
+    }
+
+    /// Consumes the atomic and returns the contained value.
+    ///
+    /// This is safe because passing `self` by value guarantees that no other
+    /// threads are concurrently accessing the atomic data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicInstant, Instant};
+    ///
+    /// let instant = AtomicInstant::now();
+    /// std::thread::sleep(core::time::Duration::from_secs(1));
+    /// assert!(instant.into_inner() < Instant::now());
+    /// ```
+    pub fn into_inner(self) -> Instant {
+        Instant {
+            nanos: self.nanos.into_inner(),
+        }
+    }
+
+    /// Loads the instant from the atomic instant.
+    ///
+    /// `load` takes an `Ordering` argument which describes the memory ordering
+    /// of this operation. Possible values are `SeqCst`, `Acquire`, and
+    /// `Relaxed`.
+    ///
+    /// # Panics
+    /// Panics if `order` is `Release` or `AcqRel`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicInstant, Instant};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let instant = AtomicInstant::now();
+    /// std::thread::sleep(core::time::Duration::from_secs(1));
+    /// assert!(instant.load(Ordering::Relaxed) < Instant::now());
+    /// ```
+    pub fn load(&self, ordering: Ordering) -> Instant {
+        Instant {
+            nanos: self.nanos.load(ordering),
+        }
+    }
+
+    /// Stores the instant into the atomic instant.
+    ///
+    /// `store` takes an `Ordering` argument which describes the memory ordering
+    /// of this operation. Possible values are `SeqCst`, `Release`, and
+    /// `Relaxed`.
+    ///
+    /// # Panics
+    /// Panics if `order` is `Acquire` or `AcqRel`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicInstant, Duration, Instant};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let instant = AtomicInstant::now();
+    ///
+    /// std::thread::sleep(core::time::Duration::from_secs(1));
+    /// assert!(instant.load(Ordering::Relaxed).elapsed() >= Duration::from_secs(1));
+    ///
+    /// instant.store(Instant::now(), Ordering::Relaxed);
+    /// assert!(instant.load(Ordering::Relaxed).elapsed() < Duration::from_secs(1));
+    /// ```
+    pub fn store(&self, value: Instant, ordering: Ordering) {
+        self.nanos.store(value.nanos, ordering)
+    }
+
+    /// Stores the instant into the atomic instant, returning the previous
+    /// value.
+    ///
+    /// `swap` takes an `Ordering` argument which describes the memory ordering
+    /// of this operation. All ordering modes are possible. Note that using
+    /// `Acquire` makes the store part of this operation `Relaxed`, and using
+    /// `Release` makes the load part `Relaxed`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicInstant, Instant};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let now = AtomicInstant::now();
+    /// std::thread::sleep(core::time::Duration::from_secs(1));
+    /// let new_now = Instant::now();
+    ///
+    /// assert!(now.swap(new_now, Ordering::Relaxed) < new_now);
+    /// ```
+    pub fn swap(&self, val: Instant, order: Ordering) -> Instant {
+        Instant {
+            nanos: self.nanos.swap(val.nanos, order),
+        }
+    }
+
+    /// Stores the instant into the atomic instant if the current value is the
+    /// same as the `current` value.
+    ///
+    /// The return value is a result indicating whether the new value was
+    /// written and containing the previous value. On success this value is
+    /// guaranteed to be equal to current.
+    ///
+    /// `compare_exchange` takes two `Ordering` arguments to describe the memory
+    /// ordering of this operation. `success` describes the required ordering
+    /// for the read-modify-write operation that takes place if the comparison
+    /// with `current` succeeds. `failure` describes the required ordering for
+    /// the load operation that takes place when the comparison fails. Using
+    /// `Acquire` as success ordering makes the store part of this operation
+    /// `Relaxed`, and using `Release makes the successful load `Relaxed`. The
+    /// failure ordering can only be, `SeqCst`, `Acquire`, or `Relaxed` and must
+    /// be equivalent to or weaker than the success ordering.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicInstant, Duration, Instant};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let instant = AtomicInstant::now();
+    /// let original = instant.load(Ordering::Relaxed);
+    ///
+    /// assert_eq!(instant.compare_exchange(
+    ///     original,
+    ///     original + Duration::from_secs(1),
+    ///     Ordering::Acquire,
+    ///     Ordering::Relaxed),
+    ///     Ok(original));
+    /// assert_eq!(instant.load(Ordering::Relaxed), original + Duration::from_secs(1));
+    ///
+    /// assert_eq!(instant.compare_exchange(
+    ///     original,
+    ///     Instant::now(),
+    ///     Ordering::Acquire,
+    ///     Ordering::Relaxed),
+    ///     Err(original + Duration::from_secs(1)));
+    /// assert_eq!(instant.load(Ordering::Relaxed), original + Duration::from_secs(1));
+    ///
+    /// ```
+    pub fn compare_exchange(
+        &self,
+        current: Instant,
+        new: Instant,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Instant, Instant> {
+        match self
+            .nanos
+            .compare_exchange(current.nanos, new.nanos, success, failure)
+        {
+            Ok(nanos) => Ok(Instant { nanos }),
+            Err(nanos) => Err(Instant { nanos }),
+        }
+    }
+
+    /// Stores the instant into the atomic instant if the current value is the
+    /// same as the `current` value.
+    ///
+    /// Unlike `AtomicDuration::compare_exchange`, this function is allowed to
+    /// spuriously fail even when the comparison succeeds, which can result in
+    /// more efficient code on some platforms. The return value is a result
+    /// indicating whether the new value was written and containing the previous
+    /// value.
+    ///
+    /// `compare_exchange_weak` takes two `Ordering` arguments to describe the
+    /// memory ordering of this operation. `success` describes the required
+    /// ordering for the read-modify-write operation that takes place if the
+    /// comparison with `current` succeeds. `failure` describes the required
+    /// ordering for the load operation that takes place when the comparison
+    /// fails. Using `Acquire` as success ordering makes the store part of this
+    /// operation `Relaxed`, and using `Release makes the successful load
+    /// `Relaxed`. The failure ordering can only be, `SeqCst`, `Acquire`, or
+    /// `Relaxed` and must be equivalent to or weaker than the success ordering.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicInstant, Instant};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let instant = AtomicInstant::now();
+    ///
+    /// let mut old = instant.load(Ordering::Relaxed);
+    /// loop {
+    ///     match instant.compare_exchange_weak(old, Instant::now(), Ordering::SeqCst, Ordering::Relaxed) {
+    ///         Ok(_) => break,
+    ///         Err(x) => old = x,
+    ///     }
+    /// }
+    /// ```
+    pub fn compare_exchange_weak(
+        &self,
+        current: Instant,
+        new: Instant,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Instant, Instant> {
+        match self
+            .nanos
+            .compare_exchange_weak(current.nanos, new.nanos, success, failure)
+        {
+            Ok(nanos) => Ok(Instant { nanos }),
+            Err(nanos) => Err(Instant { nanos }),
+        }
+    }
+}

--- a/time/src/instant/precise/mod.rs
+++ b/time/src/instant/precise/mod.rs
@@ -1,0 +1,5 @@
+mod atomic;
+mod plain;
+
+pub use atomic::*;
+pub use plain::*;

--- a/time/src/instant/precise/plain.rs
+++ b/time/src/instant/precise/plain.rs
@@ -1,0 +1,323 @@
+#![allow(clippy::needless_doctest_main)]
+
+use crate::*;
+
+use core::fmt;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+
+/// A measurement of a monotonically nondecreasing clock.
+/// Opaque and useful only with `Duration`.
+///
+/// Compared to the standard library's implementation, the internal
+/// representation is fixed at 64 bits and no attempts are made to correct for
+/// os and platform specific bugs which may cause time to appear to move
+/// backwards.
+///
+/// Another unique feature is `Duration::recent()` may be used to return a
+/// cached view of the underlying clock. `rustcommon_time::clock_refresh` should
+/// be used periodically to refresh the cached view of the underlying clock.
+/// This is particularly useful for when the cost of the system calls to read
+/// the underlying clock are too high but instants with an error bounded by the
+/// frequency of calls to refresh the clock are acceptable.
+///
+/// Note that instants are not guaranteed to be **steady**. In other words, each
+/// tick of the underlying clock may not be the same length (e.g. some seconds
+/// may be longer than others). An instant may jump forwards or experience time
+/// dilation (slow down or speed up).
+///
+/// Instants are opaque types that can only be compared to one another. There is
+/// no method to get "the number of seconds" from an instant. Instead, it only
+/// allows measuring the duration between two instants (or comparing two
+/// instants).
+///
+/// Example:
+///
+/// ```no_run
+/// use rustcommon_time::{Duration, Instant};
+/// use std::thread::sleep;
+///
+/// fn main() {
+///    let now = Instant::now();
+///
+///    // we sleep for 2 seconds
+///    sleep(core::time::Duration::new(2, 0));
+///    // it prints '2'
+///    println!("{}", now.elapsed().as_secs());
+/// }
+/// ```
+///
+/// # Underlying System calls
+/// Currently, the following system calls are being used to get the current time using `now()`:
+///
+/// |  Platform |               System call                                            |
+/// |:---------:|:--------------------------------------------------------------------:|
+/// | UNIX      | [clock_gettime (Monotonic Clock)]                                    |
+/// | Darwin    | [mach_absolute_time]                                                 |
+/// | Windows   | [QueryPerformanceCounter]                                            |
+///
+/// [QueryPerformanceCounter]: https://docs.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter
+/// [clock_gettime (Monotonic Clock)]: https://linux.die.net/man/3/clock_gettime
+/// [mach_absolute_time]: https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/KernelProgramming/services/services.html
+///
+/// **Disclaimer:** These system calls might change over time.
+///
+/// > Note: mathematical operations like [`add`] may panic if the underlying
+/// > structure cannot represent the new point in time.
+///
+/// [`add`]: Instant::add
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Instant {
+    pub(crate) nanos: u64,
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "ios"), unix))]
+fn now() -> Instant {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    unsafe {
+        libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
+    }
+    Instant {
+        nanos: ts.tv_sec as u64 * NS_PER_SECOND + ts.tv_nsec as u64,
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn now() -> Instant {
+    use mach::mach_time::{mach_absolute_time, mach_timebase_info};
+    use std::sync::Once;
+    unsafe {
+        let time = mach_absolute_time();
+
+        let info = {
+            static mut INFO: mach_timebase_info = mach_timebase_info { numer: 0, denom: 0 };
+            static ONCE: std::sync::Once = Once::new();
+
+            ONCE.call_once(|| {
+                mach_timebase_info(&mut INFO);
+            });
+            &INFO
+        };
+        Instant {
+            nanos: time * info.numer as u64 / info.denom as u64,
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn now() -> Instant {
+    use std::mem;
+    use winapi::um::profileapi;
+    use winapi::um::winnt::LARGE_INTEGER;
+    lazy_static! {
+        static ref PRF_FREQUENCY: u64 = {
+            unsafe {
+                let mut frq = mem::uninitialized();
+                let res = profileapi::QueryPerformanceFrequency(&mut frq);
+                debug_assert_ne!(res, 0, "Failed to query performance frequency, {}", res);
+                let frq = *frq.QuadPart() as u64;
+                frq
+            }
+        };
+    }
+    let cnt = unsafe {
+        let mut cnt = mem::uninitialized();
+        debug_assert_eq!(mem::align_of::<LARGE_INTEGER>(), 8);
+        let res = profileapi::QueryPerformanceCounter(&mut cnt);
+        debug_assert_ne!(res, 0, "Failed to query performance counter {}", res);
+        *cnt.QuadPart() as u64
+    };
+
+    Instant {
+        nanos: (cnt as f64 / (*PRF_FREQUENCY as f64 / 1_000_000_000_f64)) as u64,
+    }
+}
+
+impl Instant {
+    /// Returns an instant corresponding to "now".
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Instant;
+    ///
+    /// let now = Instant::now();
+    /// ```
+    pub fn now() -> Instant {
+        now()
+    }
+
+    /// Returns an instant corresponding to when
+    /// `rustcommon_time::clock_refresh` was last called.
+    ///
+    /// This is useful for when the overhead of measuring the current instant is
+    /// too high and an approximate measurement is acceptable. Typically the
+    /// clock would be refreshed by a separate thread or outside of any critical
+    /// path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::Instant;
+    ///
+    /// let recent = Instant::recent();
+    /// ```
+    pub fn recent() -> Instant {
+        _clock().recent_precise()
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `earlier` is later than `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rustcommon_time::Instant;
+    /// use std::thread::sleep;
+    ///
+    /// let now = Instant::now();
+    /// sleep(core::time::Duration::new(1, 0));
+    /// let new_now = Instant::now();
+    /// println!("{:?}", new_now.duration_since(now));
+    /// ```
+    pub fn duration_since(&self, earlier: Instant) -> Duration {
+        let nanos = self
+            .nanos
+            .checked_sub(earlier.nanos)
+            .expect("supplied instant is later than self");
+        Duration { nanos }
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or None if that instant is later than this one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rustcommon_time::Instant;
+    /// use std::thread::sleep;
+    ///
+    /// let now = Instant::now();
+    /// sleep(core::time::Duration::new(1, 0));
+    /// let new_now = Instant::now();
+    /// println!("{:?}", new_now.checked_duration_since(now));
+    /// println!("{:?}", now.checked_duration_since(new_now)); // None
+    /// ```
+    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
+        let nanos = self.nanos.checked_sub(earlier.nanos)?;
+        Some(Duration { nanos })
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or zero duration if that instant is later than this one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rustcommon_time::Instant;
+    /// use std::thread::sleep;
+    ///
+    /// let now = Instant::now();
+    /// sleep(core::time::Duration::new(1, 0));
+    /// let new_now = Instant::now();
+    /// println!("{:?}", new_now.saturating_duration_since(now));
+    /// println!("{:?}", now.saturating_duration_since(new_now)); // 0ns
+    /// ```
+    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+        let nanos = self.nanos.saturating_sub(earlier.nanos);
+        Duration { nanos }
+    }
+
+    /// Returns the amount of time elapsed since this instant was created.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if the current time is earlier than this
+    /// instant, which is something that can happen if an `Instant` is
+    /// produced synthetically.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::thread::sleep;
+    /// use rustcommon_time::{Duration, Instant};
+    ///
+    /// let instant = Instant::now();
+    /// sleep(core::time::Duration::from_secs(3));
+    /// assert!(instant.elapsed() >= Duration::from_secs(3));
+    /// ```
+    pub fn elapsed(&self) -> Duration {
+        Instant::now() - *self
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
+        let nanos = self.nanos.checked_add(duration.nanos)?;
+        Some(Instant { nanos })
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
+        let nanos = self.nanos.checked_sub(duration.nanos)?;
+        Some(Instant { nanos })
+    }
+}
+
+impl Add<Duration> for Instant {
+    type Output = Instant;
+
+    /// # Panics
+    ///
+    /// This function may panic if the resulting point in time cannot be represented by the
+    /// underlying data structure. See [`Instant::checked_add`] for a version without panic.
+    fn add(self, other: Duration) -> Instant {
+        self.checked_add(other)
+            .expect("overflow when adding duration to instant")
+    }
+}
+
+impl AddAssign<Duration> for Instant {
+    fn add_assign(&mut self, other: Duration) {
+        *self = *self + other;
+    }
+}
+
+impl Sub<Duration> for Instant {
+    type Output = Instant;
+
+    fn sub(self, other: Duration) -> Instant {
+        self.checked_sub(other)
+            .expect("overflow when subtracting duration from instant")
+    }
+}
+
+impl SubAssign<Duration> for Instant {
+    fn sub_assign(&mut self, other: Duration) {
+        *self = *self - other;
+    }
+}
+
+impl Sub<Instant> for Instant {
+    type Output = Duration;
+
+    fn sub(self, other: Instant) -> Duration {
+        self.duration_since(other)
+    }
+}
+
+impl fmt::Debug for Instant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Instant")
+            .field("nanos", &self.nanos)
+            .finish()
+    }
+}

--- a/time/src/instant/precise/plain.rs
+++ b/time/src/instant/precise/plain.rs
@@ -80,7 +80,7 @@ fn now() -> Instant {
         libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
     }
     Instant {
-        nanos: ts.tv_sec as u64 * NS_PER_SECOND + ts.tv_nsec as u64,
+        nanos: ts.tv_sec as u64 * NANOS_PER_SEC + ts.tv_nsec as u64,
     }
 }
 
@@ -131,7 +131,7 @@ fn now() -> Instant {
     };
 
     Instant {
-        nanos: (cnt as f64 / (*PRF_FREQUENCY as f64 / 1_000_000_000_f64)) as u64,
+        nanos: (cnt as f64 / (*PRF_FREQUENCY as f64 / (NANOS_PER_SEC as f64))) as u64,
     }
 }
 

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -3,9 +3,17 @@ use core::sync::atomic::AtomicU32;
 use core::sync::atomic::AtomicU64;
 use core::sync::atomic::Ordering;
 
-const NS_PER_MICROSECOND: u64 = 1_000;
-const NS_PER_MILLISECOND: u64 = 1_000_000;
-const NS_PER_SECOND: u64 = 1_000_000_000;
+mod duration;
+mod instant;
+
+pub use duration::*;
+pub use instant::*;
+
+const MILLIS_PER_SEC: u64 = 1_000;
+const MICROS_PER_SEC: u64 = 1_000_000;
+const NANOS_PER_SEC: u64 = 1_000_000_000;
+const NANOS_PER_MILLI: u64 = 1_000_000;
+const NANOS_PER_MICRO: u64 = 1_000;
 
 // We initialize the clock for the static lifetime.
 // TODO(bmartin): this probably doesn't even need to be mutable...
@@ -44,7 +52,8 @@ pub fn refresh_clock() {
 
 // Clock provides functionality to get current and recent times
 struct Clock {
-    recent: AtomicInstant,
+    recent_precise: AtomicInstant,
+    recent_coarse: AtomicCoarseInstant,
     initialized: AtomicBool,
 }
 
@@ -62,21 +71,31 @@ impl Clock {
     /// Return a cached precise time
     fn recent_precise(&self) -> Instant {
         if self.initialized.load(Ordering::Relaxed) {
-            self.recent.load(Ordering::Relaxed)
+            self.recent_precise.load(Ordering::Relaxed)
         } else {
             self.refresh();
-            self.recent.load(Ordering::Relaxed)
+            self.recent_precise.load(Ordering::Relaxed)
         }
     }
 
     /// Return a cached coarse time
     fn recent_coarse(&self) -> CoarseInstant {
-        CoarseInstant::from(self.recent_precise())
+        if self.initialized.load(Ordering::Relaxed) {
+            self.recent_coarse.load(Ordering::Relaxed)
+        } else {
+            self.refresh();
+            self.recent_coarse.load(Ordering::Relaxed)
+        }
     }
 
     /// Refresh the cached time
     fn refresh(&self) {
-        self.recent.store(Instant::now(), Ordering::Relaxed);
+        let precise = Instant::now();
+        let coarse = CoarseInstant {
+            secs: (precise.nanos / NANOS_PER_SEC) as u32,
+        };
+        self.recent_precise.store(precise, Ordering::Relaxed);
+        self.recent_coarse.store(coarse, Ordering::Relaxed);
         self.initialized.store(true, Ordering::Relaxed);
     }
 }
@@ -84,476 +103,14 @@ impl Clock {
 impl Clock {
     const fn new() -> Self {
         Clock {
-            recent: AtomicInstant {
-                ns: AtomicU64::new(0),
+            recent_precise: AtomicInstant {
+                nanos: AtomicU64::new(0),
+            },
+            recent_coarse: AtomicCoarseInstant {
+                secs: AtomicU32::new(0),
             },
             initialized: AtomicBool::new(false),
         }
-    }
-}
-
-/// `Instant` is an opaque type that represents a moment in time.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
-pub struct Instant {
-    ns: u64, // This is enough for 500 years without overflow
-}
-
-/// `CoarseInstant` is an opaque type that represents a moment in time to the
-/// nearest second.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
-pub struct CoarseInstant {
-    s: u32, // This is enough for >100 years without overflow
-}
-
-impl From<Instant> for CoarseInstant {
-    fn from(instant: Instant) -> Self {
-        Self {
-            s: (instant.ns / NS_PER_SECOND) as u32,
-        }
-    }
-}
-
-/// `AtomicCoarseInstant` is an opaque type that represents a moment in time to
-/// the nearest second. Unlike `CoarseInstant`, it is thread-safe.
-#[derive(Debug)]
-pub struct AtomicCoarseInstant {
-    s: AtomicU32, // This is enough for >100 years without overflow
-}
-
-/// `AtomicInstant` is an opaque type that represents a moment in time. Unlike
-/// `Instant`, it is thread-safe.
-pub struct AtomicInstant {
-    ns: AtomicU64,
-}
-
-impl AtomicInstant {
-    pub fn now() -> Self {
-        let instant = Instant::now();
-        Self {
-            ns: AtomicU64::new(instant.ns),
-        }
-    }
-
-    pub fn recent() -> Self {
-        let instant = _clock().recent_precise();
-        Self {
-            ns: AtomicU64::new(instant.ns),
-        }
-    }
-
-    pub fn load(&self, ordering: Ordering) -> Instant {
-        Instant {
-            ns: self.ns.load(ordering),
-        }
-    }
-
-    pub fn store(&self, value: Instant, ordering: Ordering) {
-        self.ns.store(value.ns, ordering)
-    }
-
-    pub fn fetch_add(&self, other: Duration, ordering: Ordering) -> Instant {
-        Instant {
-            ns: self.ns.fetch_add(other.ns, ordering),
-        }
-    }
-
-    pub fn fetch_sub(&self, other: Duration, ordering: Ordering) -> Instant {
-        Instant {
-            ns: self.ns.fetch_sub(other.ns, ordering),
-        }
-    }
-
-    pub fn refresh(&self, ordering: Ordering) {
-        self.store(Instant::now(), ordering)
-    }
-
-    pub fn elapsed(&self, ordering: Ordering) -> Duration {
-        self.load(ordering).elapsed()
-    }
-}
-
-impl AtomicCoarseInstant {
-    pub fn now() -> Self {
-        let instant = CoarseInstant::now();
-        Self {
-            s: AtomicU32::new(instant.s),
-        }
-    }
-
-    pub fn recent() -> Self {
-        let instant = _clock().recent_coarse();
-        Self {
-            s: AtomicU32::new(instant.s),
-        }
-    }
-
-    pub fn load(&self, ordering: Ordering) -> CoarseInstant {
-        CoarseInstant {
-            s: self.s.load(ordering),
-        }
-    }
-
-    pub fn store(&self, value: CoarseInstant, ordering: Ordering) {
-        self.s.store(value.s, ordering)
-    }
-
-    pub fn fetch_add(&self, other: CoarseDuration, ordering: Ordering) -> CoarseInstant {
-        CoarseInstant {
-            s: self.s.fetch_add(other.s, ordering),
-        }
-    }
-
-    pub fn fetch_sub(&self, other: CoarseDuration, ordering: Ordering) -> CoarseInstant {
-        CoarseInstant {
-            s: self.s.fetch_sub(other.s, ordering),
-        }
-    }
-
-    pub fn refresh(&self, ordering: Ordering) {
-        self.store(CoarseInstant::now(), ordering)
-    }
-
-    pub fn elapsed(&self, ordering: Ordering) -> CoarseDuration {
-        self.load(ordering).elapsed()
-    }
-}
-
-impl CoarseInstant {
-    pub fn now() -> Self {
-        let now = Instant::now();
-        Self {
-            s: (now.ns / NS_PER_SECOND) as u32,
-        }
-    }
-
-    pub fn recent() -> Self {
-        _clock().recent_coarse()
-    }
-
-    pub fn elapsed(&self) -> CoarseDuration {
-        CoarseInstant::now() - self
-    }
-}
-
-impl std::ops::Sub<&CoarseInstant> for CoarseInstant {
-    type Output = CoarseDuration;
-
-    fn sub(self, other: &CoarseInstant) -> <Self as std::ops::Sub<&CoarseInstant>>::Output {
-        CoarseDuration {
-            s: self.s - other.s,
-        }
-    }
-}
-
-impl std::ops::Sub<CoarseInstant> for CoarseInstant {
-    type Output = CoarseDuration;
-
-    fn sub(self, other: CoarseInstant) -> <Self as std::ops::Sub<CoarseInstant>>::Output {
-        self.sub(&other)
-    }
-}
-
-impl std::ops::Add<&CoarseDuration> for CoarseInstant {
-    type Output = CoarseInstant;
-
-    fn add(self, other: &CoarseDuration) -> <Self as std::ops::Add<&CoarseDuration>>::Output {
-        CoarseInstant {
-            s: self.s + other.s,
-        }
-    }
-}
-
-impl std::ops::Add<CoarseDuration> for CoarseInstant {
-    type Output = CoarseInstant;
-
-    fn add(self, other: CoarseDuration) -> <Self as std::ops::Add<CoarseDuration>>::Output {
-        self.add(&other)
-    }
-}
-
-impl std::ops::AddAssign<CoarseDuration> for CoarseInstant {
-    fn add_assign(&mut self, other: CoarseDuration) {
-        self.s += other.s
-    }
-}
-
-impl std::ops::Sub<&CoarseDuration> for CoarseInstant {
-    type Output = CoarseInstant;
-
-    fn sub(self, other: &CoarseDuration) -> <Self as std::ops::Sub<&CoarseDuration>>::Output {
-        CoarseInstant {
-            s: self.s - other.s,
-        }
-    }
-}
-
-impl std::ops::Sub<CoarseDuration> for CoarseInstant {
-    type Output = CoarseInstant;
-
-    fn sub(self, other: CoarseDuration) -> <Self as std::ops::Sub<CoarseDuration>>::Output {
-        self.sub(&other)
-    }
-}
-
-impl std::ops::SubAssign<CoarseDuration> for CoarseInstant {
-    fn sub_assign(&mut self, other: CoarseDuration) {
-        self.s -= other.s
-    }
-}
-
-#[cfg(all(not(target_os = "macos"), not(target_os = "ios"), unix))]
-impl Instant {
-    pub fn now() -> Self {
-        let mut ts = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-        unsafe {
-            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
-        }
-        Instant {
-            ns: ts.tv_sec as u64 * NS_PER_SECOND + ts.tv_nsec as u64,
-        }
-    }
-}
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-impl Instant {
-    pub fn now() -> Self {
-        use mach::mach_time::{mach_absolute_time, mach_timebase_info};
-        use std::sync::Once;
-        unsafe {
-            let time = mach_absolute_time();
-
-            let info = {
-                static mut INFO: mach_timebase_info = mach_timebase_info { numer: 0, denom: 0 };
-                static ONCE: std::sync::Once = Once::new();
-
-                ONCE.call_once(|| {
-                    mach_timebase_info(&mut INFO);
-                });
-                &INFO
-            };
-            Instant {
-                ns: time * info.numer as u64 / info.denom as u64,
-            }
-        }
-    }
-}
-
-#[cfg(target_os = "windows")]
-impl Instant {
-    pub fn now() -> Instant {
-        use std::mem;
-        use winapi::um::profileapi;
-        use winapi::um::winnt::LARGE_INTEGER;
-        lazy_static! {
-            static ref PRF_FREQUENCY: u64 = {
-                unsafe {
-                    let mut frq = mem::uninitialized();
-                    let res = profileapi::QueryPerformanceFrequency(&mut frq);
-                    debug_assert_ne!(res, 0, "Failed to query performance frequency, {}", res);
-                    let frq = *frq.QuadPart() as u64;
-                    frq
-                }
-            };
-        }
-        let cnt = unsafe {
-            let mut cnt = mem::uninitialized();
-            debug_assert_eq!(mem::align_of::<LARGE_INTEGER>(), 8);
-            let res = profileapi::QueryPerformanceCounter(&mut cnt);
-            debug_assert_ne!(res, 0, "Failed to query performance counter {}", res);
-            *cnt.QuadPart() as u64
-        };
-
-        Instant {
-            ns: (cnt as f64 / (*PRF_FREQUENCY as f64 / 1_000_000_000_f64)) as u64,
-        }
-    }
-}
-
-impl Instant {
-    pub fn elapsed(&self) -> Duration {
-        Instant::now() - self
-    }
-
-    pub fn recent() -> Instant {
-        _clock().recent_precise()
-    }
-}
-
-impl std::ops::Sub<&Instant> for Instant {
-    type Output = Duration;
-
-    fn sub(self, other: &Instant) -> <Self as std::ops::Sub<&Instant>>::Output {
-        Duration {
-            ns: self.ns - other.ns,
-        }
-    }
-}
-
-impl std::ops::Sub<Instant> for Instant {
-    type Output = Duration;
-
-    fn sub(self, other: Instant) -> <Self as std::ops::Sub<Instant>>::Output {
-        self.sub(&other)
-    }
-}
-
-impl std::ops::Add<&Duration> for Instant {
-    type Output = Instant;
-
-    fn add(self, other: &Duration) -> <Self as std::ops::Add<&Duration>>::Output {
-        Instant {
-            ns: self.ns + other.ns,
-        }
-    }
-}
-
-impl std::ops::Add<Duration> for Instant {
-    type Output = Instant;
-
-    fn add(self, other: Duration) -> <Self as std::ops::Add<Duration>>::Output {
-        self.add(&other)
-    }
-}
-
-impl std::ops::AddAssign<Duration> for Instant {
-    fn add_assign(&mut self, other: Duration) {
-        self.ns += other.ns
-    }
-}
-
-impl std::ops::Sub<&Duration> for Instant {
-    type Output = Instant;
-
-    fn sub(self, other: &Duration) -> <Self as std::ops::Sub<&Duration>>::Output {
-        Instant {
-            ns: self.ns - other.ns,
-        }
-    }
-}
-
-impl std::ops::Sub<Duration> for Instant {
-    type Output = Instant;
-
-    fn sub(self, other: Duration) -> <Self as std::ops::Sub<Duration>>::Output {
-        self.sub(&other)
-    }
-}
-
-impl std::ops::SubAssign<Duration> for Instant {
-    fn sub_assign(&mut self, other: Duration) {
-        self.ns -= other.ns
-    }
-}
-
-/// `CoarseDuration` is a lower-resolution version of `Duration`. It represents
-/// a period of time with one-second resolution.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
-pub struct CoarseDuration {
-    s: u32,
-}
-
-impl CoarseDuration {
-    pub const SECOND: CoarseDuration = CoarseDuration::from_secs(1);
-    pub const ZERO: CoarseDuration = CoarseDuration::from_secs(0);
-    pub const MAX: CoarseDuration = CoarseDuration::from_secs(u32::MAX);
-
-    pub const fn new(secs: u32) -> Self {
-        Self { s: secs }
-    }
-
-    pub const fn from_secs(secs: u32) -> Self {
-        Self::new(secs)
-    }
-
-    pub const fn as_sec(&self) -> u32 {
-        self.s
-    }
-
-    /// Check if the duration spans no time
-    pub const fn is_zero(&self) -> bool {
-        self.s == 0
-    }
-}
-
-/// `Duration` is the amount of time between two instants.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
-pub struct Duration {
-    ns: u64,
-}
-
-impl Duration {
-    pub const SECOND: Duration = Duration::from_nanos(NS_PER_SECOND);
-    pub const MILLISECOND: Duration = Duration::from_nanos(NS_PER_MILLISECOND);
-    pub const MICROSECOND: Duration = Duration::from_nanos(NS_PER_MICROSECOND);
-    pub const NANOSECOND: Duration = Duration::from_nanos(1);
-    pub const ZERO: Duration = Duration::from_nanos(0);
-    pub const MAX: Duration = Duration::from_nanos(u64::MAX);
-
-    /// Create a duration from the specified number of seconds.
-    ///
-    /// # Panics
-    ///
-    /// This constructor will panic if the number of seconds exceeds the maximum
-    /// representable duration.
-    pub fn from_secs(secs: u64) -> Self {
-        assert!(secs < u64::MAX / NS_PER_SECOND);
-        Self {
-            ns: secs * NS_PER_SECOND,
-        }
-    }
-
-    /// Create a duration from the specified number of milliseconds.
-    ///
-    /// # Panics
-    ///
-    /// This constructor will panic if the number of milliseconds exceeds the
-    /// maximum representable duration.
-    pub fn from_millis(millis: u64) -> Self {
-        assert!(millis < u64::MAX / NS_PER_MILLISECOND);
-        Self {
-            ns: millis * NS_PER_MILLISECOND,
-        }
-    }
-
-    /// Create a duration from the specified number of microseconds.
-    ///
-    /// # Panics
-    ///
-    /// This constructor will panic if the number of microseconds exceeds the
-    /// maximum representable duration.
-    pub fn from_micros(micros: u64) -> Self {
-        assert!(micros < u64::MAX / NS_PER_MICROSECOND);
-        Self {
-            ns: micros * NS_PER_MICROSECOND,
-        }
-    }
-
-    /// Create a duration from the specified number of nanoseconds
-    pub const fn from_nanos(nanos: u64) -> Self {
-        Self { ns: nanos }
-    }
-
-    /// Check if the duration spans no time
-    pub const fn is_zero(&self) -> bool {
-        self.ns == 0
-    }
-
-    /// Returns the total duration in fractional seconds
-    pub fn as_sec_f64(&self) -> f64 {
-        self.ns as f64 / NS_PER_SECOND as f64
-    }
-
-    /// Returns the whole number of seconds in the duration
-    pub const fn as_sec(&self) -> u64 {
-        self.ns / NS_PER_SECOND
-    }
-
-    /// Returns the total number of nanoseconds in the duration
-    pub const fn as_nanos(&self) -> u64 {
-        self.ns
     }
 }
 
@@ -567,8 +124,8 @@ mod tests {
         let now = Instant::now();
         std::thread::sleep(std::time::Duration::new(1, 0));
         let elapsed = now.elapsed();
-        assert!(elapsed.as_sec_f64() >= 1.0);
-        assert!(elapsed.as_sec() >= 1);
+        assert!(elapsed.as_secs_f64() >= 1.0);
+        assert!(elapsed.as_secs() >= 1);
         assert!(elapsed.as_nanos() >= 1_000_000_000);
     }
 
@@ -578,7 +135,7 @@ mod tests {
         let now = Instant::now();
         std::thread::sleep(std::time::Duration::new(1, 0));
         let elapsed = now.elapsed();
-        assert!(elapsed.as_sec() >= 1);
+        assert!(elapsed.as_secs() >= 1);
         assert!(elapsed.as_nanos() >= 1_000_000_000);
 
         let t0 = Instant::recent();
@@ -588,7 +145,7 @@ mod tests {
         refresh_clock();
         let t1 = Instant::recent();
         let t1_c = Instant::recent();
-        assert!((t1 - t0).as_sec_f64() >= 1.0);
-        assert!((t1_c - t0_c).as_sec() >= 1);
+        assert!((t1 - t0).as_secs_f64() >= 1.0);
+        assert!((t1_c - t0_c).as_secs() >= 1);
     }
 }


### PR DESCRIPTION
Normalize the interface for the duration types by copy-pasting from
rust std/core implementations.

This helps provide a consistent and familiar interface, improves the
documentation, and makes sure we have a more complete api.
