### PR TITLE
Fixed CircleQ pop_back_node pointer issues

### DIFF
--- a/queue/src/circleq.rs
+++ b/queue/src/circleq.rs
@@ -176,7 +176,7 @@ impl<T> CircleQ<T> {
             if self.len > 1 {
                 self.tail = node.prev;
                 (*self.tail.unwrap().as_ptr()).next = self.head;
-                (*self.head.unwrap().as_ptr()).prev = self.head;
+                (*self.head.unwrap().as_ptr()).prev = self.tail;
             } else {
                 self.head = None;
                 self.tail = None;


### PR DESCRIPTION
### Problem

Originally `pop_back_node` would set the head's `prev` pointer to `self.head` instead of `self.tail`, which is a logic error to start with. This error can also cause `split_off` to create two lists with the same node (which is UB), if used (in)correctly.

### Solution

Simply changed `pop_back_node` to correctly set the head's `prev` to `self.tail`.

### Other notes

The CircleQ seems a bit broken in general, aside from just this. Whether or not the `self.head`'s `prev` will point to `self.tail` isn't consistent. Some methods tie this up, some do not.
