### PR TITLE
Removed unsafe clock reference in favor of lazy_static

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.86"
+lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]
 lazy_static = "1.4.0"

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -2,6 +2,7 @@ use core::sync::atomic::AtomicBool;
 use core::sync::atomic::AtomicU32;
 use core::sync::atomic::AtomicU64;
 use core::sync::atomic::Ordering;
+use lazy_static::lazy_static;
 
 mod duration;
 mod instant;
@@ -16,11 +17,12 @@ const NANOS_PER_MILLI: u64 = 1_000_000;
 const NANOS_PER_MICRO: u64 = 1_000;
 
 // We initialize the clock for the static lifetime.
-// TODO(bmartin): this probably doesn't even need to be mutable...
-static mut CLOCK: Clock = Clock::new();
+lazy_static! {
+    static ref CLOCK: Clock = Clock::new();
+}
 
 fn _clock() -> &'static Clock {
-    unsafe { &CLOCK }
+    &CLOCK
 }
 
 // convenience functions


### PR DESCRIPTION
Problem

Each reference to the `Clock` object with this library takes place within an `unsafe` block. `lazy_static!` can be used here to keep this outside of an `unsafe` block, with relatively little effort.

Solution

I've added `lazy_static` as a core dependency (I left the OS conditional dependencies, but I'd be happy to remove those), and wrapped the `CLOCK` object in the `lazy_static` macro. 

Result

There's less unsafe code to run in the `time` library, and the `CLOCK` object is no longer mutable. 

Hey! I saw this project and was clicking around and I thought this would be a small but useful addition to reduce the amount of unsafe code. 🚀 
