### PR TITLE
rustcommon_time: add basic criterion benchmarks

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -16,3 +16,10 @@ mach = "0.3.2"
 
 [target.'cfg(all(not(windows), not(unix), not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
 lazy_static = "1.4.0"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "precise"
+harness = false

--- a/time/benches/precise.rs
+++ b/time/benches/precise.rs
@@ -1,0 +1,35 @@
+// use criterion::BenchmarkId;
+use criterion::Throughput;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rustcommon_time::*;
+
+fn plain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Instant");
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("now", |b| {
+        b.iter(Instant::now)
+    });
+    group.bench_function("recent", |b| {
+        b.iter(Instant::recent)
+    });
+}
+
+fn atomic(c: &mut Criterion) {
+    let mut group = c.benchmark_group("AtomicInstant");
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("now", |b| {
+        b.iter(AtomicInstant::now)
+    });
+    group.bench_function("recent", |b| {
+        b.iter(AtomicInstant::recent)
+    });
+}
+
+criterion_group!(
+    benches,
+    plain,
+    atomic,
+);
+criterion_main!(benches);

--- a/time/benches/precise.rs
+++ b/time/benches/precise.rs
@@ -7,29 +7,17 @@ fn plain(c: &mut Criterion) {
     let mut group = c.benchmark_group("Instant");
 
     group.throughput(Throughput::Elements(1));
-    group.bench_function("now", |b| {
-        b.iter(Instant::now)
-    });
-    group.bench_function("recent", |b| {
-        b.iter(Instant::recent)
-    });
+    group.bench_function("now", |b| b.iter(Instant::now));
+    group.bench_function("recent", |b| b.iter(Instant::recent));
 }
 
 fn atomic(c: &mut Criterion) {
     let mut group = c.benchmark_group("AtomicInstant");
 
     group.throughput(Throughput::Elements(1));
-    group.bench_function("now", |b| {
-        b.iter(AtomicInstant::now)
-    });
-    group.bench_function("recent", |b| {
-        b.iter(AtomicInstant::recent)
-    });
+    group.bench_function("now", |b| b.iter(AtomicInstant::now));
+    group.bench_function("recent", |b| b.iter(AtomicInstant::recent));
 }
 
-criterion_group!(
-    benches,
-    plain,
-    atomic,
-);
+criterion_group!(benches, plain, atomic,);
 criterion_main!(benches);

--- a/time/benches/precise.rs
+++ b/time/benches/precise.rs
@@ -1,4 +1,3 @@
-// use criterion::BenchmarkId;
 use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rustcommon_time::*;
@@ -19,5 +18,5 @@ fn atomic(c: &mut Criterion) {
     group.bench_function("recent", |b| b.iter(AtomicInstant::recent));
 }
 
-criterion_group!(benches, plain, atomic,);
+criterion_group!(benches, plain, atomic);
 criterion_main!(benches);


### PR DESCRIPTION
Adds basic criterion benchmarks for the precise Instant type, both
plain and atomic, to evaluate performance of any changes to the
crate.
