### PR TITLE
fastmetrics: update spin loop hint

### DIFF
--- a/fastmetrics/src/metrics.rs
+++ b/fastmetrics/src/metrics.rs
@@ -224,7 +224,7 @@ fn set_metrics(metrics: Box<dyn MetricsLib>) -> Result<(), MetricsError> {
         }
         INITIALIZING => {
             while STATE.load(Ordering::SeqCst) == INITIALIZING {
-                std::sync::atomic::spin_loop_hint();
+                std::hint::spin_loop();
             }
             Err(MetricsError::AlreadyInitialized)
         }


### PR DESCRIPTION
Migrate from deprecated `spin_loop_hint()` to `hint::spin_loop()`
