### PR TITLE
Bring in new metrics implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "histogram",
     "logger",
     "metrics",
+    "metrics-v2",
     "ratelimiter",
     "streamstats",
     "time",

--- a/metrics-v2/Cargo.toml
+++ b/metrics-v2/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "metrics-v2"
+name = "rustcommon-metrics-v2"
 version = "0.1.0"
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = ["Sean Lynch <seanl@twitter.com>"]
+license = "Apache-2.0"
 
 [dependencies]
 linkme = "0.2.6"

--- a/metrics-v2/Cargo.toml
+++ b/metrics-v2/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "metrics-v2"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+linkme = "0.2.6"
+

--- a/metrics-v2/src/counter.rs
+++ b/metrics-v2/src/counter.rs
@@ -8,6 +8,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A counter. Can be incremented or added to.
 ///
+/// In case of overflow the counter will wrap around. However, internally it
+/// uses an unsigned 64-bit integer so for most use cases this should be
+/// unlikely.
+///
 /// # Example
 /// ```
 /// # use rustcommon_metrics_v2::{metric, Counter};

--- a/metrics-v2/src/counter.rs
+++ b/metrics-v2/src/counter.rs
@@ -8,7 +8,7 @@ use std::{
 ///
 /// # Example
 /// ```
-/// # use metrics_v2::{metric, Counter};
+/// # use rustcommon_metrics_v2::{metric, Counter};
 /// metric! {
 ///     #[name = "my.custom.metric"]
 ///     static MY_COUNTER: Counter = Counter::new();

--- a/metrics-v2/src/counter.rs
+++ b/metrics-v2/src/counter.rs
@@ -1,8 +1,10 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use crate::Metric;
-use std::{
-    any::Any,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::any::Any;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A counter. Can be incremented or added to.
 ///

--- a/metrics-v2/src/counter.rs
+++ b/metrics-v2/src/counter.rs
@@ -1,0 +1,67 @@
+use crate::Metric;
+use std::{
+    any::Any,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+/// A counter. Can be incremented or added to.
+///
+/// # Example
+/// ```
+/// # use metrics_v2::{metric, Counter};
+/// metric! {
+///     #[name = "my.custom.metric"]
+///     static MY_COUNTER: Counter = Counter::new();
+/// }
+///
+/// fn a_method() {
+///     MY_COUNTER.increment();
+///     // ...
+/// }
+/// # a_method();
+/// ```
+#[derive(Default, Debug)]
+pub struct Counter(AtomicU64);
+
+impl Counter {
+    /// Create a counter initialized to 0.
+    pub const fn new() -> Self {
+        Self::with_value(0)
+    }
+
+    /// Create a counter initialized to `value`.
+    pub const fn with_value(value: u64) -> Self {
+        Self(AtomicU64::new(value))
+    }
+
+    #[inline]
+    pub fn increment(&self) -> u64 {
+        self.add(1)
+    }
+
+    #[inline]
+    pub fn add(&self, value: u64) -> u64 {
+        self.0.fetch_add(value, Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn value(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn set(&self, value: u64) -> u64 {
+        self.0.swap(value, Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn reset(&self) -> u64 {
+        self.set(0)
+    }
+}
+
+impl Metric for Counter {
+    fn as_any(&self) -> Option<&dyn Any> {
+        Some(self)
+    }
+}

--- a/metrics-v2/src/gauge.rs
+++ b/metrics-v2/src/gauge.rs
@@ -1,8 +1,10 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use crate::Metric;
-use std::{
-    any::Any,
-    sync::atomic::{AtomicI64, Ordering},
-};
+use std::any::Any;
+use std::sync::atomic::{AtomicI64, Ordering};
 
 /// A gauge. Indicates the current value of some host parameter.
 ///

--- a/metrics-v2/src/gauge.rs
+++ b/metrics-v2/src/gauge.rs
@@ -25,10 +25,12 @@ use std::{
 pub struct Gauge(AtomicI64);
 
 impl Gauge {
+    /// Create a new guage with the default value of 0.
     pub const fn new() -> Self {
         Self::with_value(0)
     }
 
+    /// Create a new guage with the provided initial value.
     pub const fn with_value(value: i64) -> Self {
         Self(AtomicI64::new(value))
     }

--- a/metrics-v2/src/gauge.rs
+++ b/metrics-v2/src/gauge.rs
@@ -8,7 +8,7 @@ use std::{
 ///
 /// # Example
 /// ```
-/// # use metrics_v2::{metric, Gauge};
+/// # use rustcommon_metrics_v2::{metric, Gauge};
 /// metric! {
 ///     #[name = "my.gauge"]
 ///     static A_METHOD_RUNNING: Gauge = Gauge::new();

--- a/metrics-v2/src/gauge.rs
+++ b/metrics-v2/src/gauge.rs
@@ -1,0 +1,76 @@
+use crate::Metric;
+use std::{
+    any::Any,
+    sync::atomic::{AtomicI64, Ordering},
+};
+
+/// A gauge. Indicates the current value of some host parameter.
+///
+/// # Example
+/// ```
+/// # use metrics_v2::{metric, Gauge};
+/// metric! {
+///     #[name = "my.gauge"]
+///     static A_METHOD_RUNNING: Gauge = Gauge::new();
+/// }
+///
+/// fn a_method() {
+///     A_METHOD_RUNNING.increment();
+///     // ...
+///     A_METHOD_RUNNING.decrement();
+/// }
+/// # a_method();
+/// ```
+#[derive(Default, Debug)]
+pub struct Gauge(AtomicI64);
+
+impl Gauge {
+    pub const fn new() -> Self {
+        Self::with_value(0)
+    }
+
+    pub const fn with_value(value: i64) -> Self {
+        Self(AtomicI64::new(value))
+    }
+
+    #[inline]
+    pub fn increment(&self) {
+        self.add(1);
+    }
+
+    #[inline]
+    pub fn decrement(&self) {
+        self.sub(1);
+    }
+
+    #[inline]
+    pub fn add(&self, value: i64) {
+        self.0.fetch_add(value, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn sub(&self, value: i64) {
+        self.0.fetch_sub(value, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn value(&self) -> i64 {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn set(&self, value: i64) -> i64 {
+        self.0.swap(value, Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn reset(&self) -> i64 {
+        self.set(0)
+    }
+}
+
+impl Metric for Gauge {
+    fn as_any(&self) -> Option<&dyn Any> {
+        Some(self)
+    }
+}

--- a/metrics-v2/src/gauge.rs
+++ b/metrics-v2/src/gauge.rs
@@ -8,6 +8,10 @@ use std::sync::atomic::{AtomicI64, Ordering};
 
 /// A gauge. Indicates the current value of some host parameter.
 ///
+/// In case of overflow/underflow the gauge will wrap around. However,
+/// internally it uses a signed 64-bit integer so for most use cases this should
+/// be unlikely.
+///
 /// # Example
 /// ```
 /// # use rustcommon_metrics_v2::{metric, Gauge};

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -1,0 +1,128 @@
+//! Easily registered distributed metrics.
+//!
+//! More docs todo...
+//!
+//! # Creating a Metric
+//! Registering a metric is straightforward. All that's needed is to declare a
+//! static within the [`metric!`] macro. By default, the metric will have the
+//! name of the path to the static variable you used to declare it but this can
+//! be overridden by adding a `#[name]` attribute.
+//!
+//! ```
+//! # use metrics_v2::{metric, Counter};
+//! metric! {
+//!     /// A counter metric named "<crate name>::COUNTER_A"
+//!     static COUNTER_A: Counter = Counter::new();
+//!
+//!     /// A counter metric named "my.metric.name"
+//!     #[name = "my.metric.name"]
+//!     static COUNTER_B: Counter = Counter::new();
+//! }
+//! ```
+//!
+//! # Accessing Metrics
+//! All metrics registered via the [`metric!`] macro can be accessed by calling
+//! the [`metrics`] function. This will return a slice with one [`MetricEntry`]
+//! instance per metric that was registered via the [`metric!`] macro.
+//!
+//! Suppose we have the metrics declared in the example above.
+//! ```
+//! # // This should remain in sync with the example above.
+//! # use metrics_v2::{metric, Counter};
+//! # metric! {
+//! #     /// A counter metric named "COUNTER_A"
+//! #     static COUNTER_A: Counter = Counter::new();
+//! #
+//! #     /// A counter metric named "my.metric.name"
+//! #     #[name = "my.metric.name"]
+//! #     static COUNTER_B: Counter = Counter::new();
+//! # }
+//! # use metrics_v2::metrics;
+//! let metrics = metrics();
+//! // Metrics may be in any arbitrary order
+//! let mut names: Vec<_> = metrics.iter().map(|metric| metric.name()).collect();
+//! names.sort();
+//!
+//! assert_eq!(names[0], "my.metric.name");
+//! assert_eq!(names[1], concat!(module_path!(), "::", "COUNTER_A"));
+//! ```
+
+use std::any::Any;
+use std::fmt;
+
+mod counter;
+mod gauge;
+mod macros;
+
+pub use crate::counter::Counter;
+pub use crate::gauge::Gauge;
+
+#[doc(hidden)]
+pub mod export {
+    pub extern crate linkme;
+
+    #[linkme::distributed_slice]
+    pub static METRICS: [crate::MetricEntry] = [..];
+}
+
+/// The list of all metrics registered via the [`metric!`] macro.
+///
+/// Names within metrics are not guaranteed to be unique and no aggregation of
+/// metrics with the same name is done.
+pub fn metrics() -> &'static [MetricEntry] {
+    &*crate::export::METRICS
+}
+
+/// Global interface to a metric.
+///
+/// Most use of metrics should use the directly declared constants.
+pub trait Metric: Sync {
+    /// Indicate whether this metric has been set up.
+    ///
+    /// Generally, if this returns `false` then the other methods on this
+    /// trait should return `None`.
+    fn is_enabled(&self) -> bool {
+        true
+    }
+
+    /// Get the current metric as an [`Any`] instance. This is meant to allow
+    /// custom processing for known metric types.
+    ///
+    /// [`Any`]: std::any::Any
+    fn as_any(&self) -> Option<&dyn Any>;
+}
+
+/// A statically declared metric entry.
+pub struct MetricEntry {
+    #[doc(hidden)]
+    pub metric: &'static dyn Metric,
+    #[doc(hidden)]
+    pub name: &'static str,
+}
+
+impl MetricEntry {
+    pub fn metric(&self) -> &'static dyn Metric {
+        self.metric
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+impl std::ops::Deref for MetricEntry {
+    type Target = dyn Metric;
+
+    fn deref(&self) -> &Self::Target {
+        self.metric()
+    }
+}
+
+impl fmt::Debug for MetricEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MetricEntry")
+            .field("name", &self.name())
+            .field("metric", &"<dyn Metric>")
+            .finish()
+    }
+}

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -45,6 +45,11 @@
 //! assert_eq!(names[0], "my.metric.name");
 //! assert_eq!(names[1], concat!(module_path!(), "::", "COUNTER_A"));
 //! ```
+//!
+//! # How it Works
+//! Behind the scenes, this crate uses the [`linkme`] crate to create a
+//! distributed slice containing a [`MetricEntry`] instance for each metric that
+//! is registered via the [`metric!`] macro.
 
 use std::any::Any;
 use std::fmt;

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -9,7 +9,7 @@
 //! be overridden by adding a `#[name]` attribute.
 //!
 //! ```
-//! # use metrics_v2::{metric, Counter};
+//! # use rustcommon_metrics_v2::*;
 //! metric! {
 //!     /// A counter metric named "<crate name>::COUNTER_A"
 //!     static COUNTER_A: Counter = Counter::new();
@@ -28,7 +28,7 @@
 //! Suppose we have the metrics declared in the example above.
 //! ```
 //! # // This should remain in sync with the example above.
-//! # use metrics_v2::{metric, Counter};
+//! # use rustcommon_metrics_v2::*;
 //! # metric! {
 //! #     /// A counter metric named "COUNTER_A"
 //! #     static COUNTER_A: Counter = Counter::new();
@@ -37,7 +37,6 @@
 //! #     #[name = "my.metric.name"]
 //! #     static COUNTER_B: Counter = Counter::new();
 //! # }
-//! # use metrics_v2::metrics;
 //! let metrics = metrics();
 //! // Metrics may be in any arbitrary order
 //! let mut names: Vec<_> = metrics.iter().map(|metric| metric.name()).collect();

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 //! Easily registered distributed metrics.
 //!
 //! More docs todo...
@@ -52,7 +56,6 @@
 //! is registered via the [`metric!`] macro.
 
 use std::any::Any;
-use std::fmt;
 
 mod counter;
 mod gauge;
@@ -98,6 +101,8 @@ pub trait Metric: Sync {
 
 /// A statically declared metric entry.
 pub struct MetricEntry {
+    // These fields need to be public until it is possibe to create a const method with 
+    // &'static dyn Metric as a parameter.
     #[doc(hidden)]
     pub metric: &'static dyn Metric,
     #[doc(hidden)]
@@ -105,10 +110,12 @@ pub struct MetricEntry {
 }
 
 impl MetricEntry {
+    /// Get a reference to the metric that this entry corresponds to.
     pub fn metric(&self) -> &'static dyn Metric {
         self.metric
     }
 
+    /// Get the name of this metric.
     pub fn name(&self) -> &'static str {
         self.name
     }
@@ -122,8 +129,8 @@ impl std::ops::Deref for MetricEntry {
     }
 }
 
-impl fmt::Debug for MetricEntry {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Debug for MetricEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MetricEntry")
             .field("name", &self.name())
             .field("metric", &"<dyn Metric>")

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -101,7 +101,7 @@ pub trait Metric: Sync {
 
 /// A statically declared metric entry.
 pub struct MetricEntry {
-    // These fields need to be public until it is possibe to create a const method with 
+    // These fields need to be public until it is possibe to create a const method with
     // &'static dyn Metric as a parameter.
     #[doc(hidden)]
     pub metric: &'static dyn Metric,

--- a/metrics-v2/src/macros.rs
+++ b/metrics-v2/src/macros.rs
@@ -90,7 +90,7 @@ macro_rules! __metric_filter_attrs {
 /// `metrics::custom::METRIC`.
 ///
 /// The name of the metric can be customized by adding a `name` attribute like
-/// so 
+/// so
 /// ```
 /// # use rustcommon_metrics_v2::{metric, Counter};
 /// metric! {

--- a/metrics-v2/src/macros.rs
+++ b/metrics-v2/src/macros.rs
@@ -1,0 +1,165 @@
+/// Macro to extract the parameter from the first #[name = "blah"] attribute
+/// or use a default otherwise.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __metric_first_name {
+  { $name:ident => { $( #[$( $attr:tt )+] )*  }} => {{
+    const NAMES: &[&'static str] = &$crate::__metric_first_name!({ $( #[$( $attr )+] )* } []);
+
+    if !NAMES.is_empty() {
+      NAMES[NAMES.len() - 1]
+    } else {
+      concat!(module_path!(), "::", stringify!($name))
+    }
+  }};
+  ( { #[name = $name:expr] $( #[$( $attr:tt )+] )* } [ $( $rest:expr ),* ] ) => {
+    $crate::__metric_first_name!({ $( #[$( $attr )+] )* } [ $name $(, $rest )* ])
+  };
+  ( { #[$( $attr:tt )+] $( #[$( $rattr:tt )+] )* } [ $( $rest:expr ),* ]) => {
+    $crate::__metric_first_name!({ $( #[$( $rattr )+] )* } [ $( $rest ),* ])
+  };
+  ( {} [ $( $rest:expr ),* ]) => {
+    [ $( $rest ),* ]
+  }
+}
+
+/// Macro that filters out attributes of the style
+/// #[name = "expr"]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __metric_filter_attrs {
+  {
+    $( #[$( $attr:tt )+] )*
+    $vis:vis static $name:ident : $ty:ty = $init:expr;
+  } => {
+    $crate::__metric_filter_attrs!(
+      { $( #[$( $attr )+] )* }
+      $vis static $name: $ty = $init;
+    );
+  };
+  (
+    {}
+    $( #[$( $attr:tt )+] )*
+    $vis:vis static $name:ident : $ty:ty = $init:expr;
+  ) => {
+    $( #[$( $attr )+] )*
+    $vis static $name: $ty = $init;
+  };
+  (
+    { #[name = $value:expr] $( [$( $left:tt )+] )* }
+    $( #[$( $attr:tt )+] )*
+    $vis:vis static $name:ident : $ty:ty = $init:expr;
+  ) => {
+    $crate::__metric_filter_attrs!(
+      { $( #[$( $left )+] )* }
+      $( #[$( $attr )+] )*
+      $vis static $name : $ty = $init;
+    );
+  };
+  (
+    { #[$( $current:tt )+] $( #[$( $left:tt )+] )* }
+    $( #[$( $attr:tt )+] )*
+    $vis:vis static $name:ident : $ty:ty = $init:expr;
+  ) => {
+    $crate::__metric_filter_attrs!(
+      { $( #[$( $left )+] )* }
+      #[$( $current )+]
+      $( #[$( $attr )+] )*
+      $vis static $name: $ty = $init;
+    );
+  }
+}
+
+/// Declare a set of new metrics.
+///
+/// These metrics will appear in the global array returned by the [`metrics`]
+/// function without anything else needing to be done.
+///
+/// # Syntax
+/// The basic syntax is
+/// ```
+/// # use metrics_v2::{metric, Counter};
+/// metric! {
+///   /// My custom metric!
+///   pub static METRIC: Counter = Counter::new();
+/// }
+/// ```
+/// The above declares a gauge metric with its name being the the fully
+/// qualified path of the metric. That is, if we declared the above in the crate
+/// `metrics` and in the module `custom` then its name would be
+/// `metrics::custom::METRIC`.
+///
+/// The name of the metric can be customized by adding a `name` attribute like
+/// so 
+/// ```
+/// # use metrics_v2::{metric, Counter};
+/// metric! {
+///   /// A counter!
+///   #[name = "my-counter"]
+///   pub static METRIC: Counter = Counter::new();
+/// }
+/// ```
+/// The above declares a counter metric with name `my-counter`. The name
+/// attribute can be freely mixed with other attributes. If multiple `name`
+/// attributes are specified then the last one will be used.
+///
+/// [`metrics`]: crate::metrics
+#[macro_export]
+macro_rules! metric {
+  {
+    $(
+      $( #[ $( $attr:tt )+ ] )*
+      $vis:vis static $name:ident : $ty:ty = $init:expr ;
+    )*
+  } => {
+    $(
+      $crate::__metric_filter_attrs! {
+        $( #[$( $attr )+] )*
+        $vis static $name: $ty = {
+          #[$crate::export::linkme::distributed_slice($crate::export::METRICS)]
+          #[linkme(crate = $crate::export::linkme)]
+          static __METRIC_ENTRY: $crate::MetricEntry = $crate::MetricEntry {
+            name: $crate::__metric_first_name!{
+              $name => {
+                $( #[$( $attr )+] )*
+              }
+            },
+            metric: &$name
+          };
+
+          $init
+        };
+      }
+    )*
+  }
+}
+
+/// We use doctests here so that we can get a separate crate for each test
+/// (since metric registration is global).
+///
+/// # Assert that the test name is as expected for non-explicit names
+/// ```
+/// use metrics_v2::*;
+/// metric! {
+///   static TEST_METRIC: Counter = Counter::new();
+/// }
+///
+/// let metrics = metrics();
+///
+/// assert_eq!(metrics.len(), 1);
+/// assert_eq!(metrics[0].name(), concat!(module_path!(), "::", "TEST_METRIC"));
+/// ```
+///
+/// # Assert that test name is as expected for named metrics
+/// ```
+/// use metrics_v2::*;
+/// metric! {
+///   #[name = "custom-name"]
+///   static METRIC: Counter = Counter::new();
+/// }
+///
+/// let metrics = metrics();
+/// assert_eq!(metrics.len(), 1);
+/// assert_eq!(metrics[0].name(), "custom-name");
+/// ```
+mod test {}

--- a/metrics-v2/src/macros.rs
+++ b/metrics-v2/src/macros.rs
@@ -78,7 +78,7 @@ macro_rules! __metric_filter_attrs {
 /// # Syntax
 /// The basic syntax is
 /// ```
-/// # use metrics_v2::{metric, Counter};
+/// # use rustcommon_metrics_v2::{metric, Counter};
 /// metric! {
 ///   /// My custom metric!
 ///   pub static METRIC: Counter = Counter::new();
@@ -92,7 +92,7 @@ macro_rules! __metric_filter_attrs {
 /// The name of the metric can be customized by adding a `name` attribute like
 /// so 
 /// ```
-/// # use metrics_v2::{metric, Counter};
+/// # use rustcommon_metrics_v2::{metric, Counter};
 /// metric! {
 ///   /// A counter!
 ///   #[name = "my-counter"]
@@ -139,7 +139,7 @@ macro_rules! metric {
 ///
 /// # Assert that the test name is as expected for non-explicit names
 /// ```
-/// use metrics_v2::*;
+/// use rustcommon_metrics_v2::*;
 /// metric! {
 ///   static TEST_METRIC: Counter = Counter::new();
 /// }
@@ -152,7 +152,7 @@ macro_rules! metric {
 ///
 /// # Assert that test name is as expected for named metrics
 /// ```
-/// use metrics_v2::*;
+/// use rustcommon_metrics_v2::*;
 /// metric! {
 ///   #[name = "custom-name"]
 ///   static METRIC: Counter = Counter::new();


### PR DESCRIPTION
## Problem

We were interested in bringing in the `metrics` crate from https://github.com/phantomical/hamerkop/metrics (which is my other gh account). 

## Solution

This PR ports over the parts of that crate that I'm happy with design-wise. Namely:
- the mechanism for registering static metrics and putting them in a single distributed slice, and,
- types for counter and gauge metrics.

The rest will be brought over or redesigned in follow-up PRs.

For now, I'm putting the new metrics implementation under a `metrics-v2` folder (name up to bikeshedding) although I think the goal should be to remove the existing `rustcommon-metrics` crate - which I think has no consumers - with this one once it is feature-complete.



