### PR TITLE
Fix missing license header

### DIFF
--- a/metrics-v2/src/macros.rs
+++ b/metrics-v2/src/macros.rs
@@ -1,3 +1,7 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 /// Macro to extract the parameter from the first #[name = "blah"] attribute
 /// or use a default otherwise.
 #[doc(hidden)]


### PR DESCRIPTION
I forgot to save a tab in vscode and missed a license header during the last PR. This PR goes and adds the missing one.

