### PR TITLE
time: add SystemTime and DateTime support

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/twitter/rustcommon"
 license = "Apache-2.0"
 
 [dependencies]
+chrono = "0.4.19"
 libc = "0.2.86"
 
 [target.'cfg(windows)'.dependencies]

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -25,34 +25,40 @@ static CLOCK: Clock = Clock::new();
 
 // convenience functions
 
-/// Returns a precise instant by reading the underlying clock.
+/// Refresh the clock and return the current instant with high precision.
 pub fn now_precise() -> Instant {
-    CLOCK.now_precise()
+    CLOCK.refresh();
+    CLOCK.recent_precise()
 }
 
-/// Returns a coarse instant by reading the underlying clock.
+/// Refresh the clock and return the current instant with reduced precision.
 pub fn now_coarse() -> CoarseInstant {
-    CLOCK.now_coarse()
+    CLOCK.refresh();
+    CLOCK.recent_coarse()
 }
 
-/// Returns the current `DateTime<Local>` by reading the underlying clock.
+/// Refresh the clock and return the current datetime in the local timezone.
 pub fn now_local() -> DateTime<Local> {
-    CLOCK.now_local()
+    CLOCK.refresh();
+    CLOCK.recent_local()
 }
 
-/// Returns the current `SystemTime` by reading the underlying clock.
+/// Refresh the clock and return the current system time.
 pub fn now_system() -> SystemTime {
-    CLOCK.now_system()
+    CLOCK.refresh();
+    CLOCK.recent_system()
 }
 
-/// Returns the current unix time by reading the underlying clock.
+/// Refresh the clock and return the current unix time in seconds.
 pub fn now_unix() -> u32 {
-    CLOCK.now_unix()
+    CLOCK.refresh();
+    CLOCK.recent_unix()
 }
 
-/// Returns the current `DateTime<Utc>` by reading the underlying clock.
+/// Refresh the clock and return the current datetime in the UTC timezone.
 pub fn now_utc() -> DateTime<Utc> {
-    CLOCK.now_utc()
+    CLOCK.refresh();
+    CLOCK.recent_utc()
 }
 
 /// Returns a recent precise instant by reading a cached view of the clock.
@@ -103,39 +109,6 @@ impl Clock {
         if !self.initialized.load(Ordering::Relaxed) {
             self.refresh();
         }
-    }
-
-    /// Return the current precise time
-    fn now_precise(&self) -> Instant {
-        Instant::now()
-    }
-
-    /// Return the current coarse time
-    fn now_coarse(&self) -> CoarseInstant {
-        CoarseInstant::now()
-    }
-
-    /// Returns the current `DateTime<Local>`
-    fn now_local(&self) -> DateTime<Local> {
-        Local::now()
-    }
-
-    /// Returns the current `SystemTime`
-    fn now_system(&self) -> SystemTime {
-        SystemTime::now()
-    }
-
-    /// Returns the current unix time in seconds
-    fn now_unix(&self) -> u32 {
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as u32
-    }
-
-    /// Returns the current `DateTime<Utc>`
-    fn now_utc(&self) -> DateTime<Utc> {
-        Utc::now()
     }
 
     /// Return a cached precise time

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -99,6 +99,12 @@ struct Clock {
 }
 
 impl Clock {
+    fn initialize(&self) {
+        if !self.initialized.load(Ordering::Relaxed) {
+            self.refresh();
+        }
+    }
+
     /// Return the current precise time
     fn now_precise(&self) -> Instant {
         Instant::now()
@@ -134,17 +140,13 @@ impl Clock {
 
     /// Return a cached precise time
     fn recent_precise(&self) -> Instant {
-        if !self.initialized.load(Ordering::Relaxed) {
-            self.refresh();
-        }
+        self.initialize();
         self.recent_precise.load(Ordering::Relaxed)
     }
 
     /// Return a cached coarse time
     fn recent_coarse(&self) -> CoarseInstant {
-        if !self.initialized.load(Ordering::Relaxed) {
-            self.refresh();
-        }
+        self.initialize();
         self.recent_coarse.load(Ordering::Relaxed)
     }
 
@@ -160,9 +162,7 @@ impl Clock {
 
     /// Return a cached UNIX time
     fn recent_unix(&self) -> u32 {
-        if !self.initialized.load(Ordering::Relaxed) {
-            self.refresh();
-        }
+        self.initialize();
         self.recent_unix.load(Ordering::Relaxed)
     }
 


### PR DESCRIPTION
Adds support to return SystemTime and DateTime types

Changes `now` methods to refresh the clock.