### PR TITLE
time: re-export chrono::prelude

### DIFF
--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -6,7 +6,7 @@ use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 pub use std::time::SystemTime;
 
-pub use chrono::{DateTime, Local, TimeZone, Utc};
+pub use chrono::prelude::*;
 
 mod duration;
 mod instant;


### PR DESCRIPTION
Change the re-export to include all of chrono::prelude to allow
for more convenient operations with `DateTime<>` types.
