### PR TITLE
metrics-v2: Implement dynamic metrics

### DIFF
--- a/metrics-v2/Cargo.toml
+++ b/metrics-v2/Cargo.toml
@@ -7,5 +7,6 @@ license = "Apache-2.0"
 
 [dependencies]
 linkme = "0.2.6"
+parking_lot = "0.11.2"
 rustcommon-metrics-derive = { path = "derive" }
 

--- a/metrics-v2/derive/src/metric.rs
+++ b/metrics-v2/derive/src/metric.rs
@@ -100,10 +100,10 @@ pub(crate) fn metric(
 
         #[export::linkme::distributed_slice(#krate::export::METRICS)]
         #[linkme(crate = export::linkme)]
-        static __: #krate::MetricEntry = #krate::MetricEntry {
-            name: #name,
-            metric: &#static_name
-        };
+        static __: #krate::MetricEntry = #krate::MetricEntry::_new_const(
+            #krate::MetricWrapper(&#static_name),
+            #name
+        );
 
         #static_expr
     }};

--- a/metrics-v2/src/dynmetrics.rs
+++ b/metrics-v2/src/dynmetrics.rs
@@ -1,10 +1,17 @@
-//! Methods and structs for workin with dynamically created and destroyed
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+//! Methods and structs for working with dynamically created and destroyed
 //! metrics.
 //!
 //! Generally users should not need to use anything in this module with the
 //! exception of [`DynPinnedMetric`] and [`DynBoxedMetric`].
 
-use std::{borrow::Cow, marker::PhantomPinned, ops::Deref, pin::Pin};
+use std::borrow::Cow;
+use std::marker::PhantomPinned;
+use std::ops::Deref;
+use std::pin::Pin;
 
 use crate::{Metric, MetricEntry};
 

--- a/metrics-v2/src/dynmetrics.rs
+++ b/metrics-v2/src/dynmetrics.rs
@@ -126,7 +126,7 @@ impl<M: Metric> DynPinnedMetric<M> {
         //  - MetricEntry::new_unchecked requires that the metric reference outlive
         //    created the MetricEntry instance.
         //
-        // Finally, register, will keep the MetricEntry instance in a global list until
+        // Finally, register will keep the MetricEntry instance in a global list until
         // the corresponding unregister call is made.
         //
         // Taking all of these together, we can guarantee that self.metric will not be

--- a/metrics-v2/src/dynmetrics.rs
+++ b/metrics-v2/src/dynmetrics.rs
@@ -1,0 +1,187 @@
+//! Methods and structs for workin with dynamically created and destroyed
+//! metrics.
+//!
+//! Generally users should not need to use anything in this module with the
+//! exception of [`DynPinnedMetric`] and [`DynBoxedMetric`].
+
+use std::{borrow::Cow, marker::PhantomPinned, ops::Deref, pin::Pin};
+
+use crate::{Metric, MetricEntry};
+
+// We use parking_lot here since it avoids lock poisioning
+use parking_lot::{const_rwlock, RwLock, RwLockReadGuard};
+
+pub(crate) struct DynMetricsRegistry {
+    metrics: Vec<MetricEntry>,
+}
+
+impl DynMetricsRegistry {
+    const fn new() -> Self {
+        Self {
+            metrics: Vec::new(),
+        }
+    }
+
+    fn register(&mut self, entry: MetricEntry) {
+        self.metrics.push(entry);
+    }
+
+    fn unregister(&mut self, metric: *const dyn Metric) {
+        self.metrics
+            .retain(|x| x.metric.0 as *const () != metric as *const ());
+    }
+
+    pub(crate) fn metrics(&self) -> &[MetricEntry] {
+        &self.metrics
+    }
+}
+
+static REGISTRY: RwLock<DynMetricsRegistry> = const_rwlock(DynMetricsRegistry::new());
+
+pub(crate) fn get_registry() -> RwLockReadGuard<'static, DynMetricsRegistry> {
+    REGISTRY.read()
+}
+
+/// Registers a new dynamic metric entry.
+///
+/// The [`MetricEntry`] instance will be kept until an [`unregister`] call is
+/// made with a metric pointer that matches the one within the [`MetricEntry`].
+/// When using this take care to note how it interacts with [`MetricEntry`]'s
+/// safety guarantees.
+pub fn register(entry: MetricEntry) {
+    REGISTRY.write().register(entry);
+}
+
+/// Unregisters all dynamic entries added via [`register`] that point to the
+/// same address as `metric`.
+///
+/// This function may remove multiple entries if the same metric has been
+/// registered multiple times.
+pub fn unregister(metric: *const dyn Metric) {
+    REGISTRY.write().unregister(metric);
+}
+
+/// A dynamic metric that stores the metric inline.
+///
+/// This is a dynamic metric that relies on pinning guarantees to ensure that
+/// the stored metric can be safely accessed from other threads looking through
+/// the global dynamic metrics registry. As it requires pinning, it is somewhat
+/// unweildy to use. Most use cases can probably use [`DynBoxedMetric`] instead.
+///
+/// To use this, first create the `DynPinnedMetric` and then, once it is pinned,
+/// call [`register`] any number of times with all of the names the metric
+/// should be registered under. When the `DynPinnedMetric` instance is dropped
+/// it will unregister all the metric entries added via [`register`].
+///
+/// # Example
+/// ```
+/// # use rustcommon_metrics_v2::*;
+/// # use std::pin::Pin;
+/// let my_dyn_metric = DynPinnedMetric::new(Counter::new());
+/// // Normally you would use some utility to do this. (e.g. pin-utils)
+/// let my_dyn_metric = unsafe { Pin::new_unchecked(&my_dyn_metric) };
+/// my_dyn_metric.register("a.dynamic.counter");
+///
+/// let metrics = metrics();
+/// assert_eq!(metrics.dynamic_metrics()[0].name(), "a.dynamic.counter");
+/// ```
+///
+/// [`register`]: crate::dynmetrics::DynPinnedMetric::register
+pub struct DynPinnedMetric<M: Metric> {
+    metric: M,
+    // This type relies on Pin's guarantees for correctness. Allowing it to be unpinned would cause
+    // errors.
+    _marker: PhantomPinned,
+}
+
+impl<M: Metric> DynPinnedMetric<M> {
+    /// Create a new `DynPinnedMetric` with the provided internal metric.
+    ///
+    /// This does not register the metric. To do that call [`register`].
+    ///
+    /// [`register`]: self::DynPinnedMetric::register
+    pub fn new(metric: M) -> Self {
+        Self {
+            metric,
+            _marker: PhantomPinned,
+        }
+    }
+
+    /// Register this metric in the global list of dynamic metrics with `name`.
+    ///
+    /// Calling this multiple times will result in the same metric being
+    /// registered multiple times under potentially different names.
+    pub fn register(self: Pin<&Self>, name: impl Into<Cow<'static, str>>) {
+        // SAFETY:
+        // To prove that this is safe we need to list out a few guarantees/requirements:
+        //  - Pin ensures that the memory of this struct instance will not be reused
+        //    until the drop call completes.
+        //  - MetricEntry::new_unchecked requires that the metric reference outlive
+        //    created the MetricEntry instance.
+        //
+        // Finally, register, will keep the MetricEntry instance in a global list until
+        // the corresponding unregister call is made.
+        //
+        // Taking all of these together, we can guarantee that self.metric will not be
+        // dropped until this instance of DynPinnedMetric is dropped itself. At that
+        // point, drop calls unregister which will drop the MetricEntry instance. This
+        // ensures that the references to self.metric in REGISTRY will always be valid
+        // and that this method is safe.
+        unsafe { register(MetricEntry::new_unchecked(&self.metric, name.into())) };
+    }
+}
+
+impl<M: Metric> Drop for DynPinnedMetric<M> {
+    fn drop(&mut self) {
+        // If this metric has not been registered then nothing will be removed.
+        unregister(&self.metric);
+    }
+}
+
+impl<M: Metric> Deref for DynPinnedMetric<M> {
+    type Target = M;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.metric
+    }
+}
+
+/// A dynamic metric that stores the metric instance on the heap.
+///
+/// This avoids a lot of the hangup with [`DynPinnedMetric`] as it allows for
+/// moving the `DynBoxedMetric` without having to worry about pinning or safety
+/// issues. However, this comes at the expense of requiring a heap allocation
+/// for the metric.
+///
+/// # Example
+/// ```
+/// # use rustcommon_metrics_v2::*;
+/// let my_gauge = DynBoxedMetric::new(Gauge::new(), "my.dynamic.gauge");
+///
+/// let metrics = metrics();
+/// assert_eq!(metrics.dynamic_metrics()[0].name(), "my.dynamic.gauge");
+/// ```
+pub struct DynBoxedMetric<M: Metric> {
+    metric: Pin<Box<DynPinnedMetric<M>>>,
+}
+
+impl<M: Metric> DynBoxedMetric<M> {
+    /// Create a new dynamic metric using the provided metric type with the
+    /// provided `name`.
+    pub fn new(metric: M, name: impl Into<Cow<'static, str>>) -> Self {
+        let metric = Box::pin(DynPinnedMetric::new(metric));
+        metric.as_ref().register(name.into());
+
+        Self { metric }
+    }
+}
+
+impl<M: Metric> Deref for DynBoxedMetric<M> {
+    type Target = M;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &*self.metric
+    }
+}

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -71,7 +71,10 @@ use std::borrow::Cow;
 mod counter;
 mod gauge;
 
+pub mod dynmetrics;
+
 pub use crate::counter::Counter;
+pub use crate::dynmetrics::{DynBoxedMetric, DynPinnedMetric};
 pub use crate::gauge::Gauge;
 pub use rustcommon_metrics_derive::metric;
 

--- a/metrics-v2/tests/dynmetrics.rs
+++ b/metrics-v2/tests/dynmetrics.rs
@@ -1,5 +1,10 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use parking_lot::{Mutex, MutexGuard};
-use std::{mem::ManuallyDrop, pin::Pin};
+use std::mem::ManuallyDrop;
+use std::pin::Pin;
 
 use rustcommon_metrics_v2::*;
 

--- a/metrics-v2/tests/dynmetrics.rs
+++ b/metrics-v2/tests/dynmetrics.rs
@@ -1,0 +1,118 @@
+use parking_lot::{Mutex, MutexGuard};
+use std::{mem::ManuallyDrop, pin::Pin};
+
+use rustcommon_metrics_v2::*;
+
+// All tests manipulate global state. Need a mutex to ensure test execution
+// doesn't overlap.
+static TEST_MUTEX: Mutex<()> = parking_lot::const_mutex(());
+
+/// RAII guard that ensures
+/// - All dynamic metrics are removed after each test
+/// - No two tests run concurrently
+struct TestGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl TestGuard {
+    pub fn new() -> Self {
+        Self {
+            _lock: TEST_MUTEX.lock(),
+        }
+    }
+}
+
+impl Drop for TestGuard {
+    fn drop(&mut self) {
+        let to_unregister = metrics()
+            .dynamic_metrics()
+            .iter()
+            .map(|entry| entry.metric() as *const dyn Metric)
+            .collect::<Vec<_>>();
+
+        for metric in to_unregister {
+            dynmetrics::unregister(metric);
+        }
+    }
+}
+
+#[test]
+fn register_unregister() {
+    let _guard = TestGuard::new();
+
+    let metric = Counter::new();
+    let entry = unsafe { MetricEntry::new_unchecked(&metric, "register_unregister".into()) };
+
+    dynmetrics::register(entry);
+
+    assert_eq!(metrics().dynamic_metrics().len(), 1);
+    dynmetrics::unregister(&metric);
+    assert_eq!(metrics().dynamic_metrics().len(), 0);
+}
+
+#[test]
+fn wrapped_register_unregister() {
+    let _guard = TestGuard::new();
+
+    let metric = DynBoxedMetric::new(Counter::new(), "wrapped_register_unregister");
+
+    assert_eq!(metrics().dynamic_metrics().len(), 1);
+    drop(metric);
+    assert_eq!(metrics().dynamic_metrics().len(), 0);
+}
+
+#[test]
+fn pinned_register_unregister() {
+    let _guard = TestGuard::new();
+
+    let mut metric_ = ManuallyDrop::new(DynPinnedMetric::new(Counter::new()));
+    let metric = unsafe { Pin::new_unchecked(&*metric_) };
+    metric.register("pinned_register_unregister");
+
+    assert_eq!(metrics().dynamic_metrics().len(), 1);
+    unsafe { ManuallyDrop::drop(&mut metric_) };
+    assert_eq!(metrics().dynamic_metrics().len(), 0);
+}
+
+#[test]
+fn pinned_scope() {
+    let _guard = TestGuard::new();
+
+    {
+        let metric = DynPinnedMetric::new(Counter::new());
+        let metric = unsafe { Pin::new_unchecked(&metric) };
+        metric.register("pinned_scope");
+
+        assert_eq!(metrics().dynamic_metrics().len(), 1);
+    }
+    assert_eq!(metrics().dynamic_metrics().len(), 0);
+}
+
+#[test]
+fn pinned_dup_register() {
+    let _guard = TestGuard::new();
+
+    {
+        let metric = DynPinnedMetric::new(Counter::new());
+        let metric = unsafe { Pin::new_unchecked(&metric) };
+        metric.register("pinned_dup_1");
+        metric.register("pinned_dup_2");
+
+        assert_eq!(metrics().dynamic_metrics().len(), 2);
+    }
+    assert_eq!(metrics().dynamic_metrics().len(), 0);
+}
+
+#[test]
+fn multi_metric() {
+    let _guard = TestGuard::new();
+
+    let m1 = DynBoxedMetric::new(Counter::new(), "multi_metric_1");
+    let m2 = DynBoxedMetric::new(Counter::new(), "multi_metric_2");
+
+    assert_eq!(metrics().dynamic_metrics().len(), 2);
+    drop(m1);
+    assert_eq!(metrics().dynamic_metrics().len(), 1);
+    drop(m2);
+    assert_eq!(metrics().dynamic_metrics().len(), 0);
+}

--- a/metrics-v2/tests/named_metric.rs
+++ b/metrics-v2/tests/named_metric.rs
@@ -9,7 +9,7 @@ static METRIC: Counter = Counter::new();
 
 #[test]
 fn metric_name_as_expected() {
-    let metrics = metrics();
+    let metrics = metrics().static_metrics();
     assert_eq!(metrics.len(), 1);
     assert_eq!(metrics[0].name(), "custom-name");
 }

--- a/metrics-v2/tests/unnamed_metric.rs
+++ b/metrics-v2/tests/unnamed_metric.rs
@@ -9,7 +9,7 @@ static TEST_METRIC: Counter = Counter::new();
 
 #[test]
 fn metric_name_as_expected() {
-    let metrics = metrics();
+    let metrics = metrics().static_metrics();
 
     assert_eq!(metrics.len(), 1);
     assert_eq!(


### PR DESCRIPTION
# Problem
Currently, the only way to register metrics in metrics-v2 is to create a static and use the `#[metric]` attribute on it. This doesn't work if the metric needs to be created dynamically or shouldn't be around for the entire lifetime of the program.

# Solution
This PR adds a global registry of dynamic metrics along with some wrapping types that make working with dynamic metrics easier. It also extends the `metrics` function to return both static and dynamic metrics.

To create and use dynamic metrics you'll have to use one of `DynPinnedMetric` or `DynBoxedMetric`. These have different tradeoffs: `DynPinnedMetric` stores the metric inline but must be pinned in order to be registered, `DynBoxedMetric` stores the metric on the heap so it can be used as a regular rust type. Otherwise these types can be used in the same way as a static metric would be since the deref to the underlying metric type.

This does make  `MetricEntry` more complicated to deal with pointers to metrics that don't have `'static` lifetimes but otherwise the interface remains fairly straightforward. 
