### PR TITLE
metrics-v2: Add `crate` macro parameter to specify custom metrics crate location

### DIFF
--- a/metrics-v2/derive/src/args.rs
+++ b/metrics-v2/derive/src/args.rs
@@ -1,0 +1,47 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use quote::ToTokens;
+use std::fmt::{Display, Formatter, Result};
+use syn::parse::{Parse, ParseStream};
+use syn::{Ident, Token};
+
+#[derive(Clone)]
+pub(crate) enum ArgName {
+    Ident(Ident),
+    Crate(Token![crate]),
+}
+
+impl Parse for ArgName {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        Ok(match () {
+            _ if lookahead.peek(Ident) => Self::Ident(input.parse()?),
+            _ if lookahead.peek(Token![crate]) => Self::Crate(input.parse()?),
+            _ => return Err(lookahead.error()),
+        })
+    }
+}
+
+impl ToTokens for ArgName {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        use self::ArgName::*;
+
+        match self {
+            Ident(ident) => ident.to_tokens(tokens),
+            Crate(krate) => krate.to_tokens(tokens),
+        }
+    }
+}
+
+impl Display for ArgName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        use self::ArgName::*;
+
+        match self {
+            Ident(ident) => ident.fmt(f),
+            Crate(_) => f.write_str("crate"),
+        }
+    }
+}

--- a/metrics-v2/derive/src/lib.rs
+++ b/metrics-v2/derive/src/lib.rs
@@ -9,9 +9,13 @@ mod metric;
 /// Declare a global metric that can be accessed via the `metrics` method.
 ///
 /// # Parameters
-/// - (optional) `name`: The name that the metric should be exposed as. If not
-///   specified then the default name is one based on the path to the metric
-///   along with its name.
+/// - (optional) `name`: The string name that the metric should be exposed as.
+///   If not specified then the default name is one based on the path to the
+///   metric along with its name.
+/// - (optional) `crate`: The path to the `rustcommon_metrics_v2` crate. This
+///   allows the `metric` macro to be used within other macros that get exported
+///   to third-party crates which may not have added `rustcommon_metrics_v2` to
+///   their Cargo.toml.
 #[proc_macro_attribute]
 pub fn metric(attr: TokenStream, item: TokenStream) -> TokenStream {
     match metric::metric(attr, item) {

--- a/metrics-v2/derive/src/lib.rs
+++ b/metrics-v2/derive/src/lib.rs
@@ -4,6 +4,7 @@
 
 use proc_macro::TokenStream;
 
+mod args;
 mod metric;
 
 /// Declare a global metric that can be accessed via the `metrics` method.

--- a/metrics-v2/derive/src/metric.rs
+++ b/metrics-v2/derive/src/metric.rs
@@ -2,20 +2,22 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use std::borrow::Cow;
+
 use proc_macro2::{Span, TokenStream};
 use proc_macro_crate::FoundCrate;
 use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{parse_quote, Error, Expr, Ident, ItemStatic, Token};
+use syn::{parse_quote, Error, Expr, Ident, ItemStatic, Path, Token};
 
-struct SingleArg<T> {
-    ident: Ident,
+struct SingleArg<T, I = Ident> {
+    ident: I,
     eq: Token![=],
     value: T,
 }
 
-impl<T: Parse> Parse for SingleArg<T> {
+impl<T: Parse, I: Parse> Parse for SingleArg<T, I> {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(Self {
             ident: input.parse()?,
@@ -25,7 +27,7 @@ impl<T: Parse> Parse for SingleArg<T> {
     }
 }
 
-impl<T: ToTokens> ToTokens for SingleArg<T> {
+impl<T: ToTokens, I: ToTokens> ToTokens for SingleArg<T, I> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.ident.to_tokens(tokens);
         self.eq.to_tokens(tokens);
@@ -36,29 +38,65 @@ impl<T: ToTokens> ToTokens for SingleArg<T> {
 #[derive(Default)]
 struct MetricArgs {
     name: Option<SingleArg<Expr>>,
+    krate: Option<SingleArg<Path, Token![crate]>>,
 }
 
 impl Parse for MetricArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut args = MetricArgs::default();
+        let mut first = true;
+
+        fn duplicate_arg_error(
+            span: Span,
+            arg: &impl std::fmt::Display,
+        ) -> syn::Result<MetricArgs> {
+            Err(Error::new(
+                span,
+                format!("Unexpected duplicate argument '{}'", arg),
+            ))
+        }
 
         while !input.is_empty() {
-            let name: Ident = input.fork().parse()?;
+            if !first {
+                let _: Token![,] = input.parse()?;
+            }
+            first = false;
 
-            match &*name.to_string() {
+            let lookahead = input.lookahead1();
+            let (arg, arg_span): (Cow<str>, _) = if lookahead.peek(Ident) {
+                let ident: Ident = input.fork().parse()?;
+                (Cow::Owned(ident.to_string()), ident.span())
+            } else if lookahead.peek(Token![crate]) {
+                (
+                    Cow::Borrowed("crate"),
+                    input.fork().parse::<Token![crate]>()?.span(),
+                )
+            } else {
+                return Err(lookahead.error());
+            };
+
+            match &*arg {
                 "name" => {
                     let name: SingleArg<Expr> = input.parse()?;
                     if args.name.is_some() {
-                        return Err(Error::new(
-                            name.span(),
-                            format!("Duplicate argument '{}'", name.ident),
-                        ));
+                        return duplicate_arg_error(name.span(), &arg);
                     }
                     args.name = Some(name);
                 }
+                "crate" => {
+                    let krate: SingleArg<Path, Token![crate]> = SingleArg {
+                        ident: input.parse()?,
+                        eq: input.parse()?,
+                        value: Path::parse_mod_style(input)?,
+                    };
+                    if args.krate.is_some() {
+                        return duplicate_arg_error(krate.span(), &arg);
+                    }
+                    args.krate = Some(krate);
+                }
                 x => {
                     return Err(Error::new(
-                        name.span(),
+                        arg_span,
                         format!("Unrecognized argument '{}'", x),
                     ))
                 }
@@ -76,12 +114,15 @@ pub(crate) fn metric(
     let mut item: ItemStatic = syn::parse(item_)?;
     let args: MetricArgs = syn::parse(attr_)?;
 
-    let krate: TokenStream = proc_macro_crate::crate_name("metrics_v2")
-        .map(|krate| match krate {
-            FoundCrate::Name(name) => Ident::new(&name, Span::call_site()).to_token_stream(),
-            FoundCrate::Itself => quote! { crate },
-        })
-        .unwrap_or(quote! { rustcommon_metrics_v2 });
+    let krate: TokenStream = match args.krate {
+        Some(krate) => krate.value.to_token_stream(),
+        None => proc_macro_crate::crate_name("rustcommon_metrics_v2")
+            .map(|krate| match krate {
+                FoundCrate::Name(name) => Ident::new(&name, Span::call_site()).to_token_stream(),
+                FoundCrate::Itself => quote! { crate },
+            })
+            .unwrap_or(quote! { rustcommon_metrics_v2 }),
+    };
 
     let name: TokenStream = match args.name {
         Some(name) => name.value.to_token_stream(),
@@ -94,11 +135,13 @@ pub(crate) fn metric(
     let static_name = &item.ident;
     let static_expr = &item.expr;
     let new_expr = parse_quote! {{
-        // Since the crate name starts with "rustc" we can't use it as part of
-        // an attribute. To work around that we need to use it here.
+        // Rustc reserves attributes that start with "rustc". Since rustcommon
+        // starts with "rustc" we can't use it directly within attributes. To
+        // work around this, we first import the exports submodule and then use
+        // that for the attributes.
         use #krate::export;
 
-        #[export::linkme::distributed_slice(#krate::export::METRICS)]
+        #[export::linkme::distributed_slice(export::METRICS)]
         #[linkme(crate = export::linkme)]
         static __: #krate::MetricEntry = #krate::MetricEntry {
             name: #name,

--- a/metrics-v2/tests/alternate_crate.rs
+++ b/metrics-v2/tests/alternate_crate.rs
@@ -1,0 +1,17 @@
+mod bonus {
+    pub use rustcommon_metrics_v2::*;
+}
+
+use bonus::Counter;
+
+#[bonus::metric(name = "test", crate = crate::bonus)]
+static METRIC: Counter = Counter::new();
+
+macro_rules! metric_in_macro {
+    () => {
+        #[$crate::bonus::metric(crate = $crate::bonus)]
+        static OTHER_METRIC: Counter = Counter::new();
+    };
+}
+
+metric_in_macro!();

--- a/metrics-v2/tests/alternate_crate.rs
+++ b/metrics-v2/tests/alternate_crate.rs
@@ -1,3 +1,7 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 mod bonus {
     pub use rustcommon_metrics_v2::*;
 }


### PR DESCRIPTION
# Problem
I've been converting the metrics in pelikan to use metrics-v2. This has involved using metrics-v2 from within a custom macro. However, the `#[metrics]` attribute macro needs to be able to find the `rustcommon_metrics_v2` crate in order to work, this is not possible when it is used by a macro in a crate that doesn't list `rustcommon_metrics_v2` in it's dependencies.

# Solution
This PR adds a `crate` argument to the `#[metrics]` attribute macro that overrides the default path to `rustcommon_metrics_v2` in the generated code. That is enough for it to be usable when reexported from a macro.
