### PR TITLE
metrics-v2: Actually search for the correct crate name

### DIFF
--- a/metrics-v2/derive/src/metric.rs
+++ b/metrics-v2/derive/src/metric.rs
@@ -105,8 +105,11 @@ pub(crate) fn metric(
         Some(krate) => krate.value.to_token_stream(),
         None => proc_macro_crate::crate_name("rustcommon-metrics-v2")
             .map(|krate| match krate {
-                FoundCrate::Name(name) => Ident::new(&name, Span::call_site()).to_token_stream(),
-                FoundCrate::Itself => quote! { crate },
+                FoundCrate::Name(name) => {
+                    assert_ne!(name, "");
+                    Ident::new(&name, Span::call_site()).to_token_stream()
+                }
+                FoundCrate::Itself => quote! { rustcommon_metrics_v2 },
             })
             .unwrap_or(quote! { rustcommon_metrics_v2 }),
     };

--- a/metrics-v2/derive/src/metric.rs
+++ b/metrics-v2/derive/src/metric.rs
@@ -103,7 +103,7 @@ pub(crate) fn metric(
 
     let krate: TokenStream = match args.krate {
         Some(krate) => krate.value.to_token_stream(),
-        None => proc_macro_crate::crate_name("rustcommon_metrics_v2")
+        None => proc_macro_crate::crate_name("rustcommon-metrics-v2")
             .map(|krate| match krate {
                 FoundCrate::Name(name) => Ident::new(&name, Span::call_site()).to_token_stream(),
                 FoundCrate::Itself => quote! { crate },

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -73,6 +73,8 @@ use std::borrow::Cow;
 mod counter;
 mod gauge;
 
+extern crate self as rustcommon_metrics_v2;
+
 pub mod dynmetrics;
 
 pub use crate::counter::Counter;


### PR DESCRIPTION
Previously we were searching for `rustcommon_metrics_v2` but the crate is actually named `rustcommon-metrics-v2`.

This wasn't noticed earlier because the fallback was to just use the exact crate name which worked most of the time. In all other cases, the crate search path was explicitly overridden.

