### PR TITLE
Adjust CI to run all doctests in a separate step and only in debug mode

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -38,7 +38,7 @@ jobs:
         name: build
         with:
           command: test
-          args: ${{ env.CARGO_FLAGS }} --workspace --no-run
+          args: ${{ env.CARGO_FLAGS }} --workspace --tests --lib --bins --examples --no-run
       - uses: actions-rs/cargo@v1
         name: test
         with:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -35,14 +35,21 @@ jobs:
         with:
           key: ${{ matrix.profile }}
       - uses: actions-rs/cargo@v1
+        name: build
         with:
           command: test
-          # rustcommon-time tests are very slow, we run it in a separate step
-          args: ${{ env.CARGO_FLAGS }} --workspace --exclude rustcommon-time
+          args: ${{ env.CARGO_FLAGS }} --workspace --no-run
       - uses: actions-rs/cargo@v1
+        name: test
         with:
           command: test
-          args: ${{ env.CARGO_FLAGS }} -p rustcommon-time -- --test-threads 16
+          args: ${{ env.CARGO_FLAGS }} --workspace --tests --lib --bins --examples
+      - uses: actions-rs/cargo@v1
+        if: ${{ matrix.profile == 'debug' }}
+        name: doctests
+        with:
+          command: test
+          args: ${{ env.CARGO_FLAGS }} --doc -- --test-threads 16
 
   # Fast clippy check to ensure things compile
   check:


### PR DESCRIPTION
# Problem
The doctests in CI are the slowest part since they need to link a binary for each one. In debug mode this isn't so bad but it is extremely slow in release mode.

# Solution
We only run the doctests in debug mode.
