### PR TITLE
metrics-v2: Allow using heatmaps as metrics

### DIFF
--- a/metrics-v2/Cargo.toml
+++ b/metrics-v2/Cargo.toml
@@ -7,6 +7,8 @@ license = "Apache-2.0"
 
 [dependencies]
 linkme = "0.2.6"
+once_cell = "1.8.0"
 parking_lot = "0.11.2"
+
 rustcommon-metrics-derive = { path = "derive" }
 

--- a/metrics-v2/Cargo.toml
+++ b/metrics-v2/Cargo.toml
@@ -5,10 +5,14 @@ edition = "2018"
 authors = ["Sean Lynch <seanl@twitter.com>"]
 license = "Apache-2.0"
 
+[features]
+# histogram = [ "rustcommon-histogram" ]
+
 [dependencies]
 linkme = "0.2.6"
 once_cell = "1.8.0"
 parking_lot = "0.11.2"
 
 rustcommon-metrics-derive = { path = "derive" }
-
+rustcommon-histogram = { path = "../histogram", optional = true }
+rustcommon-atomics   = { path = "../atomics",   optional = true }

--- a/metrics-v2/Cargo.toml
+++ b/metrics-v2/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sean Lynch <seanl@twitter.com>"]
 license = "Apache-2.0"
 
 [features]
-histogram = [ "rustcommon-histogram", "rustcommon-atomics" ]
+heatmap = [ "rustcommon-heatmap", "rustcommon-atomics" ]
 
 [dependencies]
 linkme = "0.2.6"
@@ -14,5 +14,5 @@ once_cell = "1.8.0"
 parking_lot = "0.11.2"
 
 rustcommon-metrics-derive = { path = "derive" }
-rustcommon-histogram = { path = "../histogram", optional = true }
-rustcommon-atomics   = { path = "../atomics",   optional = true }
+rustcommon-heatmap = { path = "../heatmap", optional = true }
+rustcommon-atomics = { path = "../atomics", optional = true }

--- a/metrics-v2/Cargo.toml
+++ b/metrics-v2/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sean Lynch <seanl@twitter.com>"]
 license = "Apache-2.0"
 
 [features]
-# histogram = [ "rustcommon-histogram" ]
+histogram = [ "rustcommon-histogram", "rustcommon-atomics" ]
 
 [dependencies]
 linkme = "0.2.6"

--- a/metrics-v2/src/heatmap.rs
+++ b/metrics-v2/src/heatmap.rs
@@ -4,11 +4,11 @@
 
 use crate::Metric;
 use rustcommon_atomics::AtomicU64;
-use rustcommon_histogram::AtomicHistogram;
+use rustcommon_heatmap::AtomicHeatmap;
 
-pub type Histogram = AtomicHistogram<u64, AtomicU64>;
+pub type Heatmap = AtomicHeatmap<u64, AtomicU64>;
 
-impl<V, C> Metric for AtomicHistogram<V, C>
+impl<V, C> Metric for AtomicHeatmap<V, C>
 where
     V: Send + Sync + 'static,
     C: Send + Sync + 'static,

--- a/metrics-v2/src/histogram.rs
+++ b/metrics-v2/src/histogram.rs
@@ -1,7 +1,10 @@
-use crate::Metric;
-use rustcommon_histogram::AtomicHistogram;
-use rustcommon_atomics::AtomicU64;
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 
+use crate::Metric;
+use rustcommon_atomics::AtomicU64;
+use rustcommon_histogram::AtomicHistogram;
 
 pub type Histogram = AtomicHistogram<u64, AtomicU64>;
 

--- a/metrics-v2/src/histogram.rs
+++ b/metrics-v2/src/histogram.rs
@@ -1,0 +1,16 @@
+use crate::Metric;
+use rustcommon_histogram::AtomicHistogram;
+use rustcommon_atomics::AtomicU64;
+
+
+pub type Histogram = AtomicHistogram<u64, AtomicU64>;
+
+impl<V, C> Metric for AtomicHistogram<V, C>
+where
+    V: Send + Sync + 'static,
+    C: Send + Sync + 'static,
+{
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+}

--- a/metrics-v2/src/lazy.rs
+++ b/metrics-v2/src/lazy.rs
@@ -17,7 +17,7 @@ use std::ops::{Deref, DerefMut};
 /// A value which is initialized on the first access.
 ///
 /// This type is thread-safe and can be used in statics.
-/// 
+///
 /// # Example
 /// In this example, [`Heatmap`] does not have a const `new` function so it
 /// must be constructed using [`Lazy`].
@@ -33,7 +33,7 @@ use std::ops::{Deref, DerefMut};
 /// # }
 /// # #[cfg(not(feature = "heatmap"))] fn main() {}
 /// ```
-/// 
+///
 /// [`Heatmap`]: crate::Heatmap;
 pub struct Lazy<T, F = fn() -> T> {
     cell: OnceCell<T>,

--- a/metrics-v2/src/lazy.rs
+++ b/metrics-v2/src/lazy.rs
@@ -17,6 +17,20 @@ use std::ops::{Deref, DerefMut};
 /// A value which is initialized on the first access.
 ///
 /// This type is thread-safe and can be used in statics.
+/// 
+/// # Example
+/// In this example, [`Heatmap`] does not have a const `new` function so it
+/// must be constructed using [`Lazy`].
+/// ```
+/// # #[cfg(feature = "heatmap")]
+/// # fn main() {
+/// # use rustcommon_metrics_v2::*;
+/// #[metric]
+/// static HEATMAP: Lazy<Heatmap> = Lazy::new(|| Heatmap::new(100, 2, Duration::from_secs(1)));
+/// # }
+/// ```
+/// 
+/// [`Heatmap`]: crate::Heatmap;
 pub struct Lazy<T, F = fn() -> T> {
     cell: OnceCell<T>,
     func: Cell<Option<F>>,

--- a/metrics-v2/src/lazy.rs
+++ b/metrics-v2/src/lazy.rs
@@ -25,9 +25,13 @@ use std::ops::{Deref, DerefMut};
 /// # #[cfg(feature = "heatmap")]
 /// # fn main() {
 /// # use rustcommon_metrics_v2::*;
+/// # use std::time::Duration;
 /// #[metric]
-/// static HEATMAP: Lazy<Heatmap> = Lazy::new(|| Heatmap::new(100, 2, Duration::from_secs(1)));
+/// static HEATMAP: Lazy<Heatmap> = Lazy::new(|| Heatmap::new(
+///     100, 2, Duration::from_secs(30), Duration::from_secs(1)
+/// ));
 /// # }
+/// # #[cfg(not(feature = "heatmap"))] fn main() {}
 /// ```
 /// 
 /// [`Heatmap`]: crate::Heatmap;

--- a/metrics-v2/src/lazy.rs
+++ b/metrics-v2/src/lazy.rs
@@ -1,6 +1,10 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use crate::Metric;
 use once_cell::sync::OnceCell;
-use std::cell::{Cell, UnsafeCell};
+use std::cell::Cell;
 use std::ops::{Deref, DerefMut};
 
 // Note: This implementation is mostly copied from the Lazy implementation

--- a/metrics-v2/src/lazy.rs
+++ b/metrics-v2/src/lazy.rs
@@ -1,0 +1,87 @@
+use crate::Metric;
+use once_cell::sync::OnceCell;
+use std::cell::{Cell, UnsafeCell};
+use std::ops::{Deref, DerefMut};
+
+// Note: This implementation is mostly copied from the Lazy implementation
+//       within once_cell. It only adds the `get` option to try to access
+//       the value without initializing the Lazy instance.
+//
+//       This should be replaced with the new primitives in std::lazy once
+//       those stabilize.
+
+/// A value which is initialized on the first access.
+///
+/// This type is thread-safe and can be used in statics.
+pub struct Lazy<T, F = fn() -> T> {
+    cell: OnceCell<T>,
+    func: Cell<Option<F>>,
+}
+
+unsafe impl<T, F: Send> Sync for Lazy<T, F> where OnceCell<T>: Sync {}
+
+impl<T, F> Lazy<T, F> {
+    /// Create a new lazy value with the given initializing function.
+    pub const fn new(func: F) -> Self {
+        Self {
+            cell: OnceCell::new(),
+            func: Cell::new(Some(func)),
+        }
+    }
+
+    /// If this lazy has been initialized, then return a reference to the
+    /// contained value.
+    pub fn get(this: &Self) -> Option<&T> {
+        this.cell.get()
+    }
+}
+
+impl<T, F: FnOnce() -> T> Lazy<T, F> {
+    /// Force the evaluation of this lazy value and return a reference to
+    /// the result. This is equivalent to the `Deref` impl.
+    pub fn force(this: &Self) -> &T {
+        this.cell.get_or_init(|| {
+            let func = this
+                .func
+                .take()
+                .unwrap_or_else(|| panic!("Lazy instance has previously been poisoned"));
+
+            func()
+        })
+    }
+}
+
+impl<T, F: FnOnce() -> T> Deref for Lazy<T, F> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        Lazy::force(self)
+    }
+}
+
+impl<T, F: FnOnce() -> T> DerefMut for Lazy<T, F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        Lazy::force(self);
+        self.cell.get_mut().unwrap_or_else(|| unreachable!())
+    }
+}
+
+impl<T: Default> Default for Lazy<T> {
+    /// Create a new lazy value using `default` as the initializing function.
+    fn default() -> Lazy<T> {
+        Lazy::new(T::default)
+    }
+}
+
+impl<T: Metric, F: Send + 'static> Metric for Lazy<T, F> {
+    fn is_enabled(&self) -> bool {
+        Lazy::get(self).is_some()
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        match Lazy::get(self) {
+            Some(metric) => Some(metric),
+            None => None,
+        }
+    }
+}

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -74,8 +74,8 @@ mod counter;
 mod gauge;
 mod lazy;
 
-#[cfg(feature = "histogram")]
-mod histogram;
+#[cfg(feature = "heatmap")]
+mod heatmap;
 
 extern crate self as rustcommon_metrics_v2;
 
@@ -86,8 +86,8 @@ pub use crate::dynmetrics::{DynBoxedMetric, DynPinnedMetric};
 pub use crate::gauge::Gauge;
 pub use crate::lazy::Lazy;
 
-#[cfg(feature = "histogram")]
-pub use crate::histogram::Histogram;
+#[cfg(feature = "heatmap")]
+pub use crate::heatmap::Heatmap;
 
 pub use rustcommon_metrics_derive::metric;
 
@@ -108,7 +108,7 @@ pub trait Metric: Send + Sync + 'static {
     /// Generally, if this returns `false` then the other methods on this
     /// trait should return `None`.
     fn is_enabled(&self) -> bool {
-        true
+        self.as_any().is_some()
     }
 
     /// Get the current metric as an [`Any`] instance. This is meant to allow

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -74,6 +74,9 @@ mod counter;
 mod gauge;
 mod lazy;
 
+#[cfg(feature = "histogram")]
+mod histogram;
+
 extern crate self as rustcommon_metrics_v2;
 
 pub mod dynmetrics;
@@ -82,6 +85,9 @@ pub use crate::counter::Counter;
 pub use crate::dynmetrics::{DynBoxedMetric, DynPinnedMetric};
 pub use crate::gauge::Gauge;
 pub use crate::lazy::Lazy;
+
+#[cfg(feature = "histogram")]
+pub use crate::histogram::Histogram;
 
 pub use rustcommon_metrics_derive::metric;
 

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -72,6 +72,7 @@ use std::borrow::Cow;
 
 mod counter;
 mod gauge;
+mod lazy;
 
 extern crate self as rustcommon_metrics_v2;
 
@@ -80,6 +81,8 @@ pub mod dynmetrics;
 pub use crate::counter::Counter;
 pub use crate::dynmetrics::{DynBoxedMetric, DynPinnedMetric};
 pub use crate::gauge::Gauge;
+pub use crate::lazy::Lazy;
+
 pub use rustcommon_metrics_derive::metric;
 
 #[doc(hidden)]


### PR DESCRIPTION
# Problem
We'd like to be able to use heatmaps as metrics for a couple of downstream crates.

# Solution
This PR adds support for using the `AtomicHeatmap` from `rustcommon-heatmap` as a metric. This is gated behind the `heatmap` feature of the metrics crate in case it isn't always wanted.

Since the heatmap constructor functions are not `const` I also needed to implement a lazy cell that would allow for it to be initialized at runtime. Unfortunately `once_cell::sync::Lazy` didn't have the APIs I needed and `std::lazy::Lazy` is not stable yet. As an alternative, I've written my own that is closely based on the implementation of `once_cell::sync::Lazy` and implemented `Metric` for that.

