### PR TITLE
[metrics-v2] Make gauge return the previous value on modification

### DIFF
--- a/metrics-v2/src/gauge.rs
+++ b/metrics-v2/src/gauge.rs
@@ -39,24 +39,36 @@ impl Gauge {
         Self(AtomicI64::new(value))
     }
 
+    /// Increment the value of this gauge by 1.
+    /// 
+    /// Returns the old value of the gauge.
     #[inline]
-    pub fn increment(&self) {
-        self.add(1);
+    pub fn increment(&self) -> i64 {
+        self.add(1)
     }
 
+    /// Decrement the value of this gauge by 1.
+    /// 
+    /// Returns the old value of the gauge.
     #[inline]
-    pub fn decrement(&self) {
-        self.sub(1);
+    pub fn decrement(&self) -> i64 {
+        self.sub(1)
     }
 
+    /// Increase the value of this gauge by `value`.
+    /// 
+    /// Returns the od value of the gauge.
     #[inline]
-    pub fn add(&self, value: i64) {
-        self.0.fetch_add(value, Ordering::Relaxed);
+    pub fn add(&self, value: i64) -> i64 {
+        self.0.fetch_add(value, Ordering::Relaxed)
     }
 
+    /// Decrease the value of this gauge by `value`.
+    /// 
+    /// Returns the od value of the gauge.
     #[inline]
-    pub fn sub(&self, value: i64) {
-        self.0.fetch_sub(value, Ordering::Relaxed);
+    pub fn sub(&self, value: i64) -> i64 {
+        self.0.fetch_sub(value, Ordering::Relaxed)
     }
 
     #[inline]

--- a/metrics-v2/src/gauge.rs
+++ b/metrics-v2/src/gauge.rs
@@ -40,7 +40,7 @@ impl Gauge {
     }
 
     /// Increment the value of this gauge by 1.
-    /// 
+    ///
     /// Returns the old value of the gauge.
     #[inline]
     pub fn increment(&self) -> i64 {
@@ -48,7 +48,7 @@ impl Gauge {
     }
 
     /// Decrement the value of this gauge by 1.
-    /// 
+    ///
     /// Returns the old value of the gauge.
     #[inline]
     pub fn decrement(&self) -> i64 {
@@ -56,7 +56,7 @@ impl Gauge {
     }
 
     /// Increase the value of this gauge by `value`.
-    /// 
+    ///
     /// Returns the od value of the gauge.
     #[inline]
     pub fn add(&self, value: i64) -> i64 {
@@ -64,7 +64,7 @@ impl Gauge {
     }
 
     /// Decrease the value of this gauge by `value`.
-    /// 
+    ///
     /// Returns the od value of the gauge.
     #[inline]
     pub fn sub(&self, value: i64) -> i64 {


### PR DESCRIPTION
Counter already does this so this brings Gauge up to parity. I've ended up needing this within rezolus.
