### PR TITLE
[metrics-v2] Add non-fully-lazy variant of Lazy cell

### DIFF
--- a/metrics-v2/src/lazy.rs
+++ b/metrics-v2/src/lazy.rs
@@ -57,6 +57,8 @@ impl<T, F> Lazy<T, F> {
         this.cell.get()
     }
 
+    /// If this lazy has been initialized, then return a reference to the
+    /// contained value.
     pub fn get_mut(this: &mut Self) -> Option<&mut T> {
         this.cell.get_mut()
     }
@@ -122,19 +124,20 @@ pub struct Active<T, F = fn() -> T> {
 }
 
 impl<T, F> Active<T, F> {
+    /// Create a new lazy value with the given initializing function.
     pub const fn new(func: F) -> Self {
         Self {
             cell: Lazy::new(func),
         }
     }
 
-    /// If this lazy has been initialized, then return a reference to the
+    /// If this cell has been initialized, then return a reference to the
     /// contained value.
     pub fn get(this: &Self) -> Option<&T> {
         Lazy::get(&this.cell)
     }
 
-    /// If this lazy has been initialized, then return a reference to the
+    /// If this cell has been initialized, then return a reference to the
     /// contained value.
     pub fn get_mut(this: &mut Self) -> Option<&mut T> {
         Lazy::get_mut(&mut this.cell)

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -84,7 +84,7 @@ pub mod dynmetrics;
 pub use crate::counter::Counter;
 pub use crate::dynmetrics::{DynBoxedMetric, DynPinnedMetric};
 pub use crate::gauge::Gauge;
-pub use crate::lazy::{Relaxed, Lazy};
+pub use crate::lazy::{Lazy, Relaxed};
 
 #[cfg(feature = "heatmap")]
 pub use crate::heatmap::Heatmap;

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -84,7 +84,7 @@ pub mod dynmetrics;
 pub use crate::counter::Counter;
 pub use crate::dynmetrics::{DynBoxedMetric, DynPinnedMetric};
 pub use crate::gauge::Gauge;
-pub use crate::lazy::Lazy;
+pub use crate::lazy::{Active, Lazy};
 
 #[cfg(feature = "heatmap")]
 pub use crate::heatmap::Heatmap;

--- a/metrics-v2/src/lib.rs
+++ b/metrics-v2/src/lib.rs
@@ -84,7 +84,7 @@ pub mod dynmetrics;
 pub use crate::counter::Counter;
 pub use crate::dynmetrics::{DynBoxedMetric, DynPinnedMetric};
 pub use crate::gauge::Gauge;
-pub use crate::lazy::{Active, Lazy};
+pub use crate::lazy::{Relaxed, Lazy};
 
 #[cfg(feature = "heatmap")]
 pub use crate::heatmap::Heatmap;


### PR DESCRIPTION
# Problem
In pelikan we've wanted to have metrics that need a `Lazy` but at the same time we want them to be initialized even if the client code has not used them.

# Solution
This PR introduces a wrapper around `Lazy` called `Relaxed` (name open to bikeshedding) which will also get initialized when accessed via the global metrics array. It can be used anywhere `Lazy` can and will always appear to be initialized when looking at all the metrics.

