### PR TITLE
heatmap: use rustcommon-time instead of std library

### DIFF
--- a/heatmap/Cargo.toml
+++ b/heatmap/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/twitter/rustcommon/heatmap"
 repository = "https://github.com/twitter/rustcommon"
 
 [dependencies]
-crossbeam = "0.8.0"
 rustcommon-atomics = { path = "../atomics" }
 rustcommon-histogram = { path = "../histogram" }
+rustcommon-time = { path = "../time" }
 thiserror = "1.0.20"
 
 [dev-dependencies]

--- a/heatmap/src/heatmaps/standard.rs
+++ b/heatmap/src/heatmaps/standard.rs
@@ -6,7 +6,7 @@ use crate::*;
 
 use rustcommon_histogram::{Counter, Histogram, Indexing};
 
-use std::time::{Duration, Instant};
+use rustcommon_time::{Duration, Instant};
 
 /// Heatmaps are datastructures which store counts for timestamped values over a
 /// configured time range with individual histograms arranged in a ring buffer.

--- a/heatmap/src/lib.rs
+++ b/heatmap/src/lib.rs
@@ -12,12 +12,11 @@ pub use window::Window;
 
 pub use rustcommon_atomics::{Atomic, AtomicU16, AtomicU32, AtomicU64, AtomicU8};
 pub use rustcommon_histogram::{AtomicCounter, Counter, Indexing};
+pub use rustcommon_time::{AtomicInstant, Duration, Instant};
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::time::Duration;
-    use std::time::Instant;
 
     #[test]
     fn age_out() {
@@ -26,9 +25,9 @@ mod tests {
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));
-        std::thread::sleep(Duration::from_millis(100));
+        std::thread::sleep(std::time::Duration::from_millis(100));
         assert_eq!(heatmap.percentile(0.0), Ok(1));
-        std::thread::sleep(Duration::from_millis(2000));
+        std::thread::sleep(std::time::Duration::from_millis(2000));
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
 
         let heatmap = AtomicHeatmap::<u64, AtomicU64>::new(
@@ -40,9 +39,9 @@ mod tests {
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
         heatmap.increment(Instant::now(), 1, 1);
         assert_eq!(heatmap.percentile(0.0), Ok(1));
-        std::thread::sleep(Duration::from_millis(100));
+        std::thread::sleep(std::time::Duration::from_millis(100));
         assert_eq!(heatmap.percentile(0.0), Ok(1));
-        std::thread::sleep(Duration::from_millis(2000));
+        std::thread::sleep(std::time::Duration::from_millis(2000));
         assert_eq!(heatmap.percentile(0.0), Err(HeatmapError::Empty));
     }
 }

--- a/heatmap/src/window/mod.rs
+++ b/heatmap/src/window/mod.rs
@@ -3,7 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use rustcommon_histogram::Histogram;
-use std::time::Instant;
+use rustcommon_time::Instant;
 
 pub struct Window<Value, Count> {
     pub(crate) start: Instant,

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -14,6 +14,7 @@ dashmap = "3.11.10"
 rustcommon-atomics = { path = "../atomics" }
 rustcommon-heatmap = { path = "../heatmap" }
 rustcommon-streamstats = { path = "../streamstats" }
+rustcommon-time = { path = "../time" }
 thiserror = "1.0.20"
 
 [dev-dependencies]

--- a/metrics/src/channel/mod.rs
+++ b/metrics/src/channel/mod.rs
@@ -9,12 +9,11 @@ use crate::traits::*;
 use crate::MetricsError;
 use crate::Output;
 use crate::Summary;
+use rustcommon_time::Instant;
 
 use crossbeam::atomic::AtomicCell;
 use dashmap::DashSet;
 use rustcommon_atomics::{Atomic, AtomicBool, Ordering};
-
-use std::time::Instant;
 
 /// Internal type which stores fields necessary to track a corresponding
 /// statistic.

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -20,11 +20,12 @@ pub use traits::{Count, Primitive, Statistic, Value};
 
 // Re-export atomic trait and types for convenience
 pub use rustcommon_atomics::{Atomic, AtomicU16, AtomicU32, AtomicU64, AtomicU8};
+// Re-export time types for convenience
+pub use rustcommon_time::*;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{Duration, Instant};
 
     enum TestStat {
         Alpha,

--- a/metrics/src/metrics/mod.rs
+++ b/metrics/src/metrics/mod.rs
@@ -6,14 +6,14 @@ use crate::channel::Channel;
 use crate::entry::Entry;
 use crate::outputs::ApproxOutput;
 use crate::*;
-use core::hash::Hash;
-use core::hash::Hasher;
+
+use core::hash::{Hash, Hasher};
 
 use dashmap::DashMap;
 use rustcommon_atomics::*;
+use rustcommon_time::Instant;
 
 use std::collections::HashMap;
-use std::time::Instant;
 
 /// `Metrics` serves as a registry of outputs which are included in snapshots.
 /// In addition, it serves as the core storage of measurements and summary

--- a/metrics/src/summary/mod.rs
+++ b/metrics/src/summary/mod.rs
@@ -7,11 +7,8 @@ use crate::*;
 use core::marker::PhantomData;
 
 use rustcommon_atomics::Atomic;
-use rustcommon_heatmap::AtomicHeatmap;
+use rustcommon_heatmap::{AtomicHeatmap, Duration, Instant};
 use rustcommon_streamstats::AtomicStreamstats;
-
-use core::time::Duration;
-use std::time::Instant;
 
 pub(crate) enum SummaryStruct<Value, Count>
 where

--- a/time/src/instant/precise/atomic.rs
+++ b/time/src/instant/precise/atomic.rs
@@ -24,6 +24,25 @@ pub struct AtomicInstant {
 }
 
 impl AtomicInstant {
+    /// Create a new `AtomicInstant` which represents the specified `Instant`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicInstant, Instant, Duration};
+    ///
+    /// // this is the same as `AtomicInstant::now()`
+    /// let now = AtomicInstant::new(Instant::now());
+    ///
+    /// // conveniently represent an `Instant` in the future
+    /// let future = AtomicInstant::new(Instant::now() + Duration::from_secs(60));
+    /// ```
+    pub fn new(instant: Instant) -> Self {
+        Self {
+            nanos: AtomicU64::new(instant.nanos),
+        }
+    }
+
     /// Returns an instant corresponding to "now".
     ///
     /// # Examples
@@ -267,6 +286,31 @@ impl AtomicInstant {
         {
             Ok(nanos) => Ok(Instant { nanos }),
             Err(nanos) => Err(Instant { nanos }),
+        }
+    }
+
+    /// Adds a `Duration` to the `AtomicInstant` and returns the previous value.
+    ///
+    /// `fetch_add` takes an `Ordering` argument which describes the memory
+    /// ordering of this operation. All ordering modes are possible. Note that
+    /// using `Acquire` makes the store part of this operation `Relaxed`, and
+    /// using `Release` makes the load part `Relaxed`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustcommon_time::{AtomicInstant, Duration};
+    /// use core::sync::atomic::Ordering;
+    ///
+    /// let instant = AtomicInstant::now();
+    /// let duration = Duration::from_secs(10);
+    /// let previous = instant.fetch_add(duration, Ordering::Relaxed);
+    ///
+    /// assert_eq!(instant.load(Ordering::Relaxed), previous + duration);
+    /// ```
+    pub fn fetch_add(&self, duration: Duration, ordering: Ordering) -> Instant {
+        Instant {
+            nanos: self.nanos.fetch_add(duration.nanos, ordering),
         }
     }
 }

--- a/waterfall/examples/simulator.rs
+++ b/waterfall/examples/simulator.rs
@@ -4,10 +4,9 @@
 
 use rand::thread_rng;
 use rand_distr::*;
+use rustcommon_heatmap::*;
 use rustcommon_logger::*;
 use rustcommon_waterfall::*;
-use std::time::Duration;
-use std::time::Instant;
 
 fn main() {
     Logger::new()
@@ -52,7 +51,7 @@ pub fn simulate(shape: Shape) {
     let gamma = Gamma::new(2.0, 2.0).unwrap();
 
     let mut rng = thread_rng();
-    let start = std::time::Instant::now();
+    let start = Instant::now();
     loop {
         if start.elapsed() >= duration {
             break;

--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -18,7 +18,6 @@ use core::hash::Hash;
 use core::ops::Sub;
 use std::collections::HashMap;
 use std::convert::{From, TryInto};
-use std::time::{Duration, Instant};
 
 #[derive(Copy, Clone)]
 /// Used to configure various strategies for mapping values to colors
@@ -211,7 +210,7 @@ where
             }
         }
 
-        let offset = now_instant - begin_instant;
+        let offset = std::time::Duration::from_nanos((now_instant - begin_instant).as_nanos() as _);
         let offset = chrono::Duration::from_std(offset).unwrap();
 
         let begin_utc = now_datetime.checked_sub_signed(offset).unwrap();
@@ -219,10 +218,10 @@ where
 
         // add the timestamp labels along the left side
         for (y, slice) in heatmap.into_iter().enumerate() {
+            let duration =
+                std::time::Duration::from_nanos((slice.start() - begin_instant).as_nanos() as _);
             let slice_start_utc = begin_utc
-                .checked_add_signed(
-                    chrono::Duration::from_std(slice.start() - begin_instant).unwrap(),
-                )
+                .checked_add_signed(chrono::Duration::from_std(duration).unwrap())
                 .unwrap();
 
             if slice.start() - begin >= self.interval {


### PR DESCRIPTION
For convenience in high-performance services, it would be better
to support using the types from rustcommon-time to represent both
instants and durations. This allows for using cached reads of the
system clock where appropriate.
