### PR TITLE
metrics-v2: add ThreadLocalCounter

### DIFF
--- a/metrics-v2/Cargo.toml
+++ b/metrics-v2/Cargo.toml
@@ -2,7 +2,10 @@
 name = "rustcommon-metrics-v2"
 version = "0.1.0"
 edition = "2018"
-authors = ["Sean Lynch <seanl@twitter.com>"]
+authors = [
+	"Sean Lynch <seanl@twitter.com>",
+	"Brian Martin <bmartin@twitter.com",
+]
 license = "Apache-2.0"
 
 [features]
@@ -11,6 +14,7 @@ heatmap = [ "rustcommon-heatmap", "rustcommon-atomics" ]
 [dependencies]
 linkme = "0.2.6"
 once_cell = "1.8.0"
+os-thread-local = "0.1.3"
 parking_lot = "0.11.2"
 
 rustcommon-metrics-derive = { path = "derive" }

--- a/metrics-v2/src/counter/mod.rs
+++ b/metrics-v2/src/counter/mod.rs
@@ -6,6 +6,10 @@ use crate::Metric;
 use std::any::Any;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+mod thread_local;
+
+pub use thread_local::Counter as ThreadLocalCounter;
+
 /// A counter. Can be incremented or added to.
 ///
 /// In case of overflow the counter will wrap around. However, internally it

--- a/metrics-v2/src/counter/thread_local.rs
+++ b/metrics-v2/src/counter/thread_local.rs
@@ -1,0 +1,86 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use os_thread_local::ThreadLocal;
+use core::cell::RefCell;
+use crate::lazy::Lazy;
+use crate::Metric;
+use std::any::Any;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A counter which updates a thread local counter which can then be synced with
+/// the global atomic counter. Can be incremented or added to. Unlike the normal
+/// counter, this counter must by synced to the global atomic counter for
+/// increments/adds to be visible to other threads. This can be done by calling
+/// `sync()` or by loading the value.
+///
+/// In case of overflow the counter will wrap around. However, internally it
+/// uses an unsigned 64-bit integer so for most use cases this should be
+/// unlikely.
+///
+/// # Example
+/// ```
+/// # use rustcommon_metrics_v2::{metric, ThreadLocalCounter as Counter};
+/// #[metric(name = "my.custom.metric")]
+/// static MY_COUNTER: Counter = Counter::new();
+///
+/// fn a_method() {
+///     MY_COUNTER.increment();
+///     // ...
+/// }
+/// # a_method();
+/// ```
+pub struct Counter {
+    global: AtomicU64,
+    local: Lazy<ThreadLocal<RefCell<u64>>>,
+}
+
+impl Counter {
+    /// Creates a new counter with thread local caching of writes.
+    pub const fn new() -> Self {
+        Self {
+            global: AtomicU64::new(0),
+            local: Lazy::new(|| { ThreadLocal::new(|| RefCell::new(0)) }),
+        }
+    }
+
+    /// Updates and reads the global counter. Requires one atomic operation.
+    pub fn value(&self) -> u64 {
+        let local = self.local.with(|v| *v.borrow());
+        if local == 0 {
+            self.global.load(Ordering::Relaxed)
+        } else {
+            let value = self.global.fetch_add(local, Ordering::Relaxed) + local;
+            self.local.with(|v| *v.borrow_mut() = 0);
+            value
+        }
+    }
+
+    /// Synchronize the thread local counts with the global counter. Requires
+    /// one atomic operation if not currently synced.
+    pub fn sync(&self) {
+        let local = self.local.with(|v| *v.borrow());
+        if local != 0 {
+            self.global.fetch_add(local, Ordering::Relaxed);
+            self.local.with(|v| *v.borrow_mut() = 0);
+        }
+    }
+
+    /// Adds a value to the counter. No atomic operations required.
+    pub fn add(&self, value: u64) {
+        self.local.with(|v| *v.borrow_mut() += value)
+    }
+
+    /// Increment the counter by one. No atomic operations required.
+    pub fn increment(&self) {
+        self.add(1)
+    }
+}
+
+
+impl Metric for Counter {
+    fn as_any(&self) -> Option<&dyn Any> {
+        Some(self)
+    }
+}

--- a/metrics-v2/tests/thread_local.rs
+++ b/metrics-v2/tests/thread_local.rs
@@ -1,0 +1,49 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use rustcommon_metrics_v2::*;
+use rustcommon_metrics_v2::ThreadLocalCounter as Counter;
+
+#[metric(name = "alpha")]
+static ALPHA: Counter = Counter::new();
+
+#[metric(name = "bravo")]
+static BRAVO: Counter = Counter::new();
+
+#[test]
+fn thread_local_counter() {
+    // basic behaviors when using only one thread
+    assert_eq!(ALPHA.value(), 0);
+    assert_eq!(BRAVO.value(), 0);
+    ALPHA.increment();
+    assert_eq!(ALPHA.value(), 1);
+    assert_eq!(BRAVO.value(), 0);
+
+    // if a thread exits without flushing, the count won't increment
+    std::thread::spawn(move|| {
+        ALPHA.increment();
+        BRAVO.increment();
+    }).join().unwrap();
+    assert_eq!(ALPHA.value(), 1);
+    assert_eq!(BRAVO.value(), 0);
+
+    // as long as the thread flushes the counter, the new count is reflected
+    std::thread::spawn(move|| {
+        ALPHA.increment();
+        BRAVO.increment();
+        rustcommon_metrics_v2::sync();
+    }).join().unwrap();
+    assert_eq!(ALPHA.value(), 2);
+    assert_eq!(BRAVO.value(), 1);
+
+    // we can also operate on all the metrics to 
+    std::thread::spawn(move|| {
+        ALPHA.add(1);
+        BRAVO.add(1);
+        rustcommon_metrics_v2::sync();
+    }).join().unwrap();
+    assert_eq!(ALPHA.value(), 3);
+    assert_eq!(BRAVO.value(), 2);
+}
+


### PR DESCRIPTION
Adds an eventually consistent counter type that uses thread local
storage to cache add/increment of counter values. This helps reduce
the number of atomic operations that are required but comes at the
cost of additional complexity. Each thread must periodically flush
the ThreadLocalCounters for updates to be seen globally.
