### PR TITLE
remove dependency on time crate

### DIFF
--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/twitter/rustcommon"
 
 [dependencies]
 log = { version = "0.4.8", features = ["std"] }
-time = "0.1.42"
+rustcommon-time = { path = "../time" }

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -4,8 +4,10 @@
 
 #![deny(clippy::all)]
 
-pub extern crate log;
-extern crate time;
+#![macro_use]
+extern crate log;
+
+use rustcommon_time::now_local;
 
 #[macro_export]
 macro_rules! fatal {
@@ -83,7 +85,7 @@ impl log::Log for Logger {
             );
             println!(
                 "{}.{} {:<5} [{}] {}",
-                time::strftime("%Y-%m-%d %H:%M:%S", &time::now()).unwrap(),
+                time::strftime("%Y-%m-%d %H:%M:%S", now_local()).unwrap(),
                 ms,
                 record.level(),
                 target,

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -3,7 +3,6 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 #![deny(clippy::all)]
-
 #![macro_use]
 extern crate log;
 

--- a/ratelimiter/Cargo.toml
+++ b/ratelimiter/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/twitter/rustcommon"
 rand = "0.7.3"
 rand_distr = "0.2.2"
 rustcommon-atomics = { path = "../atomics" }
-time = "0.1.42"
+rustcommon-time = { path = "../time" }

--- a/ratelimiter/examples/blastoff.rs
+++ b/ratelimiter/examples/blastoff.rs
@@ -2,14 +2,18 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_time::{now_utc, SecondsFormat};
 use rustcommon_ratelimiter::Ratelimiter;
+use rustcommon_time::{now_utc, SecondsFormat};
 
 fn main() {
     let limiter = Ratelimiter::new(1, 1, 1);
     for i in 0..10 {
         limiter.wait();
-        println!("{}: T -{}", now_utc().to_rfc3339_opts(SecondsFormat::Millis, false), 10 - i);
+        println!(
+            "{}: T -{}",
+            now_utc().to_rfc3339_opts(SecondsFormat::Millis, false),
+            10 - i
+        );
     }
     limiter.wait();
     println!("Ignition");

--- a/ratelimiter/examples/blastoff.rs
+++ b/ratelimiter/examples/blastoff.rs
@@ -2,13 +2,14 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use rustcommon_time::{now_utc, SecondsFormat};
 use rustcommon_ratelimiter::Ratelimiter;
 
 fn main() {
     let limiter = Ratelimiter::new(1, 1, 1);
     for i in 0..10 {
         limiter.wait();
-        println!("T -{}", 10 - i);
+        println!("{}: T -{}", now_utc().to_rfc3339_opts(SecondsFormat::Millis, false), 10 - i);
     }
     limiter.wait();
     println!("Ignition");

--- a/ratelimiter/examples/bursty.rs
+++ b/ratelimiter/examples/bursty.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use rustcommon_time::{SecondsFormat, now_utc};
 use rustcommon_ratelimiter::{Ratelimiter, Refill};
 
 fn main() {
@@ -11,9 +12,9 @@ fn main() {
         limiter.set_strategy(*strategy);
         for i in 0..10 {
             limiter.wait();
-            println!("{}: T -{}", time::precise_time_ns(), 10 - i);
+            println!("{}: T -{}", now_utc().to_rfc3339_opts(SecondsFormat::Millis, false), 10 - i);
         }
         limiter.wait();
-        println!("");
+        println!();
     }
 }

--- a/ratelimiter/examples/bursty.rs
+++ b/ratelimiter/examples/bursty.rs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_time::{SecondsFormat, now_utc};
 use rustcommon_ratelimiter::{Ratelimiter, Refill};
+use rustcommon_time::{now_utc, SecondsFormat};
 
 fn main() {
     for strategy in &[Refill::Normal, Refill::Uniform] {
@@ -12,7 +12,11 @@ fn main() {
         limiter.set_strategy(*strategy);
         for i in 0..10 {
             limiter.wait();
-            println!("{}: T -{}", now_utc().to_rfc3339_opts(SecondsFormat::Millis, false), 10 - i);
+            println!(
+                "{}: T -{}",
+                now_utc().to_rfc3339_opts(SecondsFormat::Millis, false),
+                10 - i
+            );
         }
         limiter.wait();
         println!();

--- a/ratelimiter/src/lib.rs
+++ b/ratelimiter/src/lib.rs
@@ -6,11 +6,11 @@
 
 #![deny(clippy::all)]
 
-use rustcommon_time::Instant;
-use rustcommon_time::Duration;
+use core::convert::TryFrom;
 use rustcommon_time::AtomicDuration;
 use rustcommon_time::AtomicInstant;
-use core::convert::TryFrom;
+use rustcommon_time::Duration;
+use rustcommon_time::Instant;
 
 use rand_distr::{Distribution, Normal, Uniform};
 use rustcommon_atomics::*;
@@ -103,7 +103,8 @@ impl Ratelimiter {
 
     /// Returns the current rate
     pub fn rate(&self) -> u64 {
-        SECOND * self.quantum.load(Ordering::Relaxed) / self.tick.load(Ordering::Relaxed).as_nanos() as u64
+        SECOND * self.quantum.load(Ordering::Relaxed)
+            / self.tick.load(Ordering::Relaxed).as_nanos() as u64
     }
 
     /// Changes the refill strategy
@@ -125,7 +126,12 @@ impl Ratelimiter {
             };
             if self
                 .next
-                .compare_exchange(next, next + Duration::from_nanos(tick), Ordering::SeqCst, Ordering::SeqCst)
+                .compare_exchange(
+                    next,
+                    next + Duration::from_nanos(tick),
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                )
                 .is_ok()
             {
                 let quantum = self.quantum.load(Ordering::Relaxed);

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-time"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 description = "Library for getting current and recent timestamps"
@@ -9,7 +9,7 @@ repository = "https://github.com/twitter/rustcommon"
 license = "Apache-2.0"
 
 [dependencies]
-chrono = "0.4.19"
+chrono = { version = "0.4.19", default-features = false, features = ["std", "clock"] }
 libc = "0.2.86"
 
 [target.'cfg(windows)'.dependencies]

--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/twitter/rustcommon/waterfall"
 repository = "https://github.com/twitter/rustcommon"
 
 [dependencies]
-chrono = "0.4.15"
+chrono = { version = "0.4.15", default-features = false }
 dejavu = "2.37.0"
 image = "0.23.9"
 log = "0.4.8"


### PR DESCRIPTION
Problem

The time crate has an open vulnerability RUSTSEC-2020-0071

Solution

Remove the dependency and move to using rustcommon-time where
possible.

Result

Resolves RUSTSEC-2020-0071 error in cargo audit without any
changes to public API.
