### PR TITLE
fix RUSTSEC-2020-0159

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -6,7 +6,7 @@
 #![macro_use]
 extern crate log;
 
-use rustcommon_time::{now_local, SecondsFormat};
+use rustcommon_time::{now_utc, SecondsFormat};
 
 #[macro_export]
 macro_rules! fatal {
@@ -80,7 +80,7 @@ impl log::Log for Logger {
             };
             println!(
                 "{} {:<5} [{}] {}",
-                now_local().to_rfc3339_opts(SecondsFormat::Millis, false),
+                now_utc().to_rfc3339_opts(SecondsFormat::Millis, false),
                 record.level(),
                 target,
                 record.args()

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/twitter/rustcommon"
 license = "Apache-2.0"
 
 [dependencies]
-chrono = { version = "0.4.19", default-features = false, features = ["std", "clock"] }
 libc = "0.2.86"
+time = { version = "0.3.3", features = ["formatting"] }
 
 [target.'cfg(windows)'.dependencies]
 lazy_static = "1.4.0"

--- a/time/src/datetime.rs
+++ b/time/src/datetime.rs
@@ -1,0 +1,115 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::Duration;
+use core::fmt::Display;
+use core::fmt::Formatter;
+use core::ops::Add;
+use core::ops::Sub;
+use time::OffsetDateTime;
+
+pub enum SecondsFormat {
+    Secs,
+    Millis,
+    Micros,
+    Nanos,
+}
+
+#[derive(Copy, Clone)]
+pub struct DateTime {
+    pub(crate) inner: OffsetDateTime,
+}
+
+impl DateTime {
+    pub fn to_rfc3339_opts(&self, seconds_format: SecondsFormat, use_z: bool) -> String {
+        let date = self.inner.date();
+        let time = self.inner.time();
+        let tz = if use_z { "Z" } else { "+00:00" };
+        let seconds = match seconds_format {
+            SecondsFormat::Secs => {
+                format!("{:02}", time.second())
+            }
+            SecondsFormat::Millis => {
+                format!("{:02}.{:03}", time.second(), time.millisecond())
+            }
+            SecondsFormat::Micros => {
+                format!("{:02}.{:06}", time.second(), time.microsecond())
+            }
+            SecondsFormat::Nanos => {
+                format!("{:02}.{:09}", time.second(), time.nanosecond())
+            }
+        };
+        format!(
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{}{}",
+            date.year(),
+            date.month() as u8,
+            date.day(),
+            time.hour(),
+            time.minute(),
+            seconds,
+            tz
+        )
+    }
+}
+
+impl Add<Duration> for DateTime {
+    type Output = DateTime;
+    fn add(self, rhs: Duration) -> <Self as std::ops::Add<Duration>>::Output {
+        DateTime {
+            inner: self.inner + core::time::Duration::from_nanos(rhs.as_nanos() as u64),
+        }
+    }
+}
+
+impl Sub<Duration> for DateTime {
+    type Output = DateTime;
+    fn sub(self, rhs: Duration) -> <Self as std::ops::Sub<Duration>>::Output {
+        DateTime {
+            inner: self.inner - core::time::Duration::from_nanos(rhs.as_nanos() as u64),
+        }
+    }
+}
+
+impl Add<core::time::Duration> for DateTime {
+    type Output = DateTime;
+    fn add(
+        self,
+        rhs: core::time::Duration,
+    ) -> <Self as std::ops::Add<core::time::Duration>>::Output {
+        DateTime {
+            inner: self.inner + rhs,
+        }
+    }
+}
+
+impl Sub<core::time::Duration> for DateTime {
+    type Output = DateTime;
+    fn sub(
+        self,
+        rhs: core::time::Duration,
+    ) -> <Self as std::ops::Sub<core::time::Duration>>::Output {
+        DateTime {
+            inner: self.inner - rhs,
+        }
+    }
+}
+
+impl Display for DateTime {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
+        let date = self.inner.date();
+        let time = self.inner.time();
+
+        write!(
+            f,
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+            date.year(),
+            date.month() as u8,
+            date.day(),
+            time.hour(),
+            time.minute(),
+            time.second(),
+            time.millisecond()
+        )
+    }
+}

--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -9,12 +9,12 @@ homepage = "https://github.com/twitter/rustcommon/waterfall"
 repository = "https://github.com/twitter/rustcommon"
 
 [dependencies]
-chrono = { version = "0.4.15", default-features = false }
 dejavu = "2.37.0"
 image = "0.23.9"
 log = "0.4.8"
 rustcommon-heatmap = { path = "../heatmap" }
 rustcommon-histogram = { path = "../histogram" }
+rustcommon-time = { path = "../time" }
 rusttype = "0.9.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Replaces dependency on chrono with time 0.3.3 to resolve the
RUSTSEC-2020-0159 issue. This removes support for local timezone
in rustcommon-time and changes the logger behavior to use UTC.

Problem

`chrono` has an open advisory: RUSTSEC-2020-0159 which is unlikely
to be fixed within the crate.

Solution

The latest `time` crate 0.3.3 is not vulnerable and we can use it to
replace chrono for getting human date times. However, we are
dropping local timezone support and forcing use of UTC.

Result

RUSTSEC-2020-0159 is now resolved and cargo audit passes.

Usage of rustcommon-time that depended on local timezone
support will need to migrate to using UTC.
