### PR TITLE
fix benchmarks

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.55.0
+          override: true
 
       - name: Update cargo flags
         if: ${{ matrix.profile == 'release' }}

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.55.0
 
       - name: Update cargo flags
         if: ${{ matrix.profile == 'release' }}

--- a/heatmap/benches/heatmaps.rs
+++ b/heatmap/benches/heatmaps.rs
@@ -1,7 +1,7 @@
-use rustcommon_time::{Duration, Instant};
 use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rustcommon_heatmap::*;
+use rustcommon_time::{Duration, Instant};
 
 fn u64_u64(c: &mut Criterion) {
     let mut heatmap =

--- a/heatmap/benches/heatmaps.rs
+++ b/heatmap/benches/heatmaps.rs
@@ -1,8 +1,7 @@
-use core::time::Duration;
+use rustcommon_time::{Duration, Instant};
 use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rustcommon_heatmap::*;
-use std::time::Instant;
 
 fn u64_u64(c: &mut Criterion) {
     let mut heatmap =

--- a/metrics/benches/counters.rs
+++ b/metrics/benches/counters.rs
@@ -2,7 +2,7 @@ use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rustcommon_metrics::*;
 use std::sync::Arc;
-use std::time::Instant;
+use rustcommon_time::Instant;
 
 enum StatU8 {
     Alpha,

--- a/metrics/benches/counters.rs
+++ b/metrics/benches/counters.rs
@@ -1,8 +1,8 @@
 use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rustcommon_metrics::*;
-use std::sync::Arc;
 use rustcommon_time::Instant;
+use std::sync::Arc;
 
 enum StatU8 {
     Alpha,


### PR DESCRIPTION
Benchmarks weren't updated as part of #96 and #97. This change
fixes the benchmarks to use the time types in rustcommon-time
