### PR TITLE
time: increase precision for UTC and unix times

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcommon-time"
-version = "0.0.8"
+version = "0.0.9"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 description = "Library for getting current and recent timestamps"

--- a/time/benches/precise.rs
+++ b/time/benches/precise.rs
@@ -1,3 +1,7 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rustcommon_time::*;

--- a/time/examples/demo.rs
+++ b/time/examples/demo.rs
@@ -1,3 +1,7 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use rustcommon_time::*;
 
 pub fn main() {

--- a/time/examples/demo.rs
+++ b/time/examples/demo.rs
@@ -1,0 +1,11 @@
+use rustcommon_time::*;
+
+pub fn main() {
+    refresh_clock();
+    println!("precise: {:?}", recent_precise());
+    println!("coarse: {:?}", recent_coarse());
+    println!("system: {:?}", recent_system());
+    println!("unix coarse: {:?}", recent_unix());
+    println!("unix precise: {:?}", recent_unix_precise());
+    println!("utc: {}", recent_utc());
+}


### PR DESCRIPTION
Increases the precision of UTC timestamps to include sub-second
component.

Adds new unix precise functions to return the unix time with
nanosecond resolution.
