### PR TITLE
time: allow constructing unix instants for specific times

### DIFF
--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -62,12 +62,12 @@ mod tests {
         assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
         let now = Instant::<Nanoseconds<u64>>::now();
         metrics
-            .record_counter(&TestStat::Alpha, now, 0)
+            .record_counter(&TestStat::Alpha, now + Duration::from_millis(500), 0)
             .expect("failed to record counter");
         assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
         assert_eq!(metrics.percentile(&TestStat::Alpha, 0.0), Ok(0));
         metrics
-            .record_counter(&TestStat::Alpha, now + Duration::from_millis(1000), 1)
+            .record_counter(&TestStat::Alpha, now + Duration::from_millis(1500), 1)
             .expect("failed to record counter");
         assert_eq!(metrics.reading(&TestStat::Alpha), Ok(1));
         assert_eq!(metrics.percentile(&TestStat::Alpha, 100.0), Ok(1));

--- a/time/src/unix.rs
+++ b/time/src/unix.rs
@@ -89,6 +89,12 @@ impl UnixInstant<Seconds<u32>> {
         CLOCK.initialize();
         CLOCK.coarse_unix.load(Ordering::Relaxed)
     }
+
+    pub fn from_secs(secs: u32) -> Self {
+        UnixInstant {
+            inner: Seconds { inner: secs },
+        }
+    }
 }
 
 impl core::fmt::Debug for UnixInstant<Seconds<u32>> {
@@ -120,6 +126,12 @@ impl UnixInstant<Nanoseconds<u64>> {
     pub fn recent() -> Self {
         CLOCK.initialize();
         CLOCK.precise_unix.load(Ordering::Relaxed)
+    }
+
+    pub fn from_nanos(nanos: u64) -> Self {
+        UnixInstant {
+            inner: Nanoseconds { inner: nanos },
+        }
     }
 }
 


### PR DESCRIPTION
When working with raw unix times, it would be helpful to convert
them into `UnixInstant` types so we can perform normal instant
math.

Adds constructors to create coarse and precise `UnixInstant`s from
raw values.
