### PR TITLE
metrics: update linkme and use stable rust for testing

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -20,8 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
-          override: true
+          toolchain: stable
 
       - name: Update cargo flags
         if: ${{ matrix.profile == 'release' }}

--- a/metrics-v2/Cargo.toml
+++ b/metrics-v2/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0"
 heatmap = [ "rustcommon-heatmap", "rustcommon-atomics" ]
 
 [dependencies]
-linkme = "0.2.6"
-once_cell = "1.8.0"
+linkme = "0.2.9"
+once_cell = "1.9.0"
 parking_lot = "0.11.2"
 
 rustcommon-metrics-derive = { path = "derive" }


### PR DESCRIPTION
Updates linkme to a new version which contains a fix to allow us
to use current stable Rust.
