### PR TITLE
time: add consts for common durations

### DIFF
--- a/streamstats/src/lib.rs
+++ b/streamstats/src/lib.rs
@@ -179,15 +179,9 @@ where
 
     fn values(&self) -> usize {
         match self.current.cmp(&self.oldest) {
-            std::cmp::Ordering::Less => {
-                (self.current + self.buffer.len()) - self.oldest
-            }
-            std::cmp::Ordering::Equal => {
-                0
-            }
-            std::cmp::Ordering::Greater => {
-                self.current - self.oldest
-            }
+            std::cmp::Ordering::Less => (self.current + self.buffer.len()) - self.oldest,
+            std::cmp::Ordering::Equal => 0,
+            std::cmp::Ordering::Greater => self.current - self.oldest,
         }
     }
 

--- a/time/src/duration.rs
+++ b/time/src/duration.rs
@@ -62,6 +62,16 @@ where
 impl<T> Copy for Duration<T> where T: Copy {}
 
 impl Duration<Seconds<u32>> {
+    pub const SECOND: Self = Self {
+        inner: Seconds { inner: 1 },
+    };
+    pub const ZERO: Self = Self {
+        inner: Seconds { inner: 0 },
+    };
+    pub const MAX: Self = Self {
+        inner: Seconds { inner: u32::MAX },
+    };
+
     pub const fn from_secs(seconds: u32) -> Self {
         Self {
             inner: Seconds { inner: seconds },
@@ -103,6 +113,31 @@ atomic!(Duration<Seconds<AtomicU32>>, Seconds<u32>);
 atomic_arithmetic!(Duration<Seconds<AtomicU32>>, Duration<Seconds<u32>>);
 
 impl Duration<Nanoseconds<u64>> {
+    pub const SECOND: Self = Self {
+        inner: Nanoseconds {
+            inner: NANOS_PER_SEC,
+        },
+    };
+    pub const MILLISECOND: Self = Self {
+        inner: Nanoseconds {
+            inner: NANOS_PER_MILLI,
+        },
+    };
+    pub const MICROSECOND: Self = Self {
+        inner: Nanoseconds {
+            inner: NANOS_PER_MICRO,
+        },
+    };
+    pub const NANOSECOND: Self = Self {
+        inner: Nanoseconds { inner: 1 },
+    };
+    pub const ZERO: Self = Self {
+        inner: Nanoseconds { inner: 0 },
+    };
+    pub const MAX: Self = Self {
+        inner: Nanoseconds { inner: u64::MAX },
+    };
+
     pub const fn from_nanos(nanoseconds: u64) -> Self {
         Self {
             inner: Nanoseconds { inner: nanoseconds },
@@ -113,7 +148,7 @@ impl Duration<Nanoseconds<u64>> {
         Self {
             inner: Nanoseconds {
                 inner: microseconds
-                    .checked_mul(1_000)
+                    .checked_mul(NANOS_PER_MICRO)
                     .expect("the specified duration could not be represented with this type"),
             },
         }
@@ -123,7 +158,7 @@ impl Duration<Nanoseconds<u64>> {
         Self {
             inner: Nanoseconds {
                 inner: milliseconds
-                    .checked_mul(1_000_000)
+                    .checked_mul(NANOS_PER_MILLI)
                     .expect("the specified duration could not be represented with this type"),
             },
         }
@@ -133,7 +168,7 @@ impl Duration<Nanoseconds<u64>> {
         Self {
             inner: Nanoseconds {
                 inner: seconds
-                    .checked_mul(1_000_000_000)
+                    .checked_mul(NANOS_PER_SEC)
                     .expect("the specified duration could not be represented with this type"),
             },
         }
@@ -143,16 +178,24 @@ impl Duration<Nanoseconds<u64>> {
         self.inner.inner as f64 / NANOS_PER_SEC as f64
     }
 
-    pub fn as_nanos(&self) -> u64 {
+    pub const fn as_nanos(&self) -> u64 {
         self.inner.inner
     }
 
-    pub fn as_secs(&self) -> u32 {
-        (self.inner.inner / NANOS_PER_SEC) as u32
+    pub const fn as_secs(&self) -> u64 {
+        self.inner.inner / NANOS_PER_SEC
     }
 
-    pub fn subsec_nanos(&self) -> u64 {
+    pub const fn subsec_nanos(&self) -> u64 {
         self.inner.inner % NANOS_PER_SEC
+    }
+
+    pub const fn as_millis(&self) -> u64 {
+        self.inner.inner / NANOS_PER_MILLI
+    }
+
+    pub const fn as_micros(&self) -> u64 {
+        self.inner.inner / NANOS_PER_MICRO
     }
 
     pub fn mul_f64(self, rhs: f64) -> Self {

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -20,6 +20,8 @@ pub use units::*;
 pub use unix::*;
 
 pub(crate) const NANOS_PER_SEC: u64 = 1_000_000_000;
+pub(crate) const NANOS_PER_MILLI: u64 = 1_000_000;
+pub(crate) const NANOS_PER_MICRO: u64 = 1_000;
 
 const UNINITIALIZED: usize = 0;
 const INITIALIZED: usize = 1;


### PR DESCRIPTION
Add consts for common durations like those in core::time::Duration.
