### PR TITLE
time: change duration_since() to match std library

### DIFF
--- a/time/src/macros.rs
+++ b/time/src/macros.rs
@@ -144,9 +144,7 @@ macro_rules! instant {
 
             pub fn duration_since(&self, earlier: Self) -> Duration<$unit> {
                 Duration {
-                    inner: self
-                        .inner
-                        .saturating_sub(earlier.inner),
+                    inner: self.inner.saturating_sub(earlier.inner),
                 }
             }
 

--- a/time/src/macros.rs
+++ b/time/src/macros.rs
@@ -146,8 +146,7 @@ macro_rules! instant {
                 Duration {
                     inner: self
                         .inner
-                        .checked_sub(earlier.inner)
-                        .expect("supplied instant is later than self"),
+                        .saturating_sub(earlier.inner),
                 }
             }
 


### PR DESCRIPTION
The Rust standard library changed the behavior of duration_since()
to be a saturating operation.

This change makes sure out library behaves the same way.
