### PR TITLE
metric namespace

### DIFF
--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -192,6 +192,7 @@ pub trait Metric: Send + Sync + 'static {
 pub struct MetricEntry {
     metric: MetricWrapper,
     name: Cow<'static, str>,
+    namespace: Option<&'static str>,
     description: Option<&'static str>,
 }
 
@@ -200,8 +201,14 @@ impl MetricEntry {
     pub const fn _new_const(
         metric: MetricWrapper,
         name: &'static str,
+        namespace: &'static str,
         description: &'static str,
     ) -> Self {
+        let namespace = if namespace.is_empty() {
+            None
+        } else {
+            Some(namespace)
+        };
         let description = if description.is_empty() {
             None
         } else {
@@ -210,6 +217,7 @@ impl MetricEntry {
         Self {
             metric,
             name: Cow::Borrowed(name),
+            namespace,
             description,
         }
     }
@@ -230,6 +238,7 @@ impl MetricEntry {
         Self {
             metric: MetricWrapper(metric),
             name,
+            namespace: None,
             description: None,
         }
     }
@@ -242,6 +251,11 @@ impl MetricEntry {
     /// Get the name of this metric.
     pub fn name(&self) -> &str {
         &*self.name
+    }
+
+    /// Get the namespace of this metric.
+    pub fn namespace(&self) -> Option<&str> {
+        self.namespace
     }
 
     /// Get the description of this metric.

--- a/metrics/tests/namespaced_metric.rs
+++ b/metrics/tests/namespaced_metric.rs
@@ -7,10 +7,7 @@ use rustcommon_metrics::*;
 #[metric(name = "pid")]
 static PID: Gauge = Gauge::new();
 
-#[metric(
-    name = "composed/response",
-    namespace = "server"
-)]
+#[metric(name = "composed/response", namespace = "server")]
 static COMPOSED_RESPONSE: Counter = Counter::new();
 
 #[test]
@@ -26,8 +23,5 @@ fn with_namespace() {
     let metrics = metrics().static_metrics();
     assert_eq!(metrics.len(), 2);
     assert_eq!(metrics[0].name(), "composed/response");
-    assert_eq!(
-        metrics[0].namespace(),
-        Some("server")
-    );
+    assert_eq!(metrics[0].namespace(), Some("server"));
 }

--- a/metrics/tests/namespaced_metric.rs
+++ b/metrics/tests/namespaced_metric.rs
@@ -1,0 +1,33 @@
+// Copyright 2022 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use rustcommon_metrics::*;
+
+#[metric(name = "pid")]
+static PID: Gauge = Gauge::new();
+
+#[metric(
+    name = "composed/response",
+    namespace = "server"
+)]
+static COMPOSED_RESPONSE: Counter = Counter::new();
+
+#[test]
+fn without_namespace() {
+    let metrics = metrics().static_metrics();
+    assert_eq!(metrics.len(), 2);
+    assert_eq!(metrics[1].name(), "pid");
+    assert_eq!(metrics[1].namespace(), None);
+}
+
+#[test]
+fn with_namespace() {
+    let metrics = metrics().static_metrics();
+    assert_eq!(metrics.len(), 2);
+    assert_eq!(metrics[0].name(), "composed/response");
+    assert_eq!(
+        metrics[0].namespace(),
+        Some("server")
+    );
+}


### PR DESCRIPTION
By adding an optional namespace for each metric, we can easily change the displayed metric name by including some prefix. For example, we may want to prefix client metrics with `client` but only if we're also displaying `server` metrics (for example, in a proxy). This can be achieved by combining feature flags and custom macros.
