### PR TITLE
metrics: fix heatmap macro

### DIFF
--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -140,12 +140,14 @@ macro_rules! heatmap {
             name = rustcommon_metrics::to_lowercase!($name)
         )]
         pub static $name: Relaxed<Heatmap> = Relaxed::new(|| {
-            Heatmap::new(
-                $max as _,
-                3,
-                rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(60),
-                rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(1),
-            )
+            Heatmap::builder()
+                .maximum_value($max as _)
+                .min_resolution(1)
+                .min_resolution_range(1024)
+                .span(rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(60))
+                .resolution(rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(1))
+                .build()
+                .expect("bad heatmap configuration")
         });
     };
     ($name:ident, $max:expr, $description:tt) => {
@@ -154,12 +156,14 @@ macro_rules! heatmap {
             description = $description
         )]
         pub static $name: Relaxed<Heatmap> = Relaxed::new(|| {
-            Heatmap::new(
-                $max as _,
-                3,
-                rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(60),
-                rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(1),
-            )
+            Heatmap::builder()
+                .maximum_value($max as _)
+                .min_resolution(1)
+                .min_resolution_range(1024)
+                .span(rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(60))
+                .resolution(rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(1))
+                .build()
+                .expect("bad heatmap configuration")
         });
     };
 }

--- a/metrics/tests/heatmap.rs
+++ b/metrics/tests/heatmap.rs
@@ -1,0 +1,27 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use rustcommon_metrics::*;
+
+heatmap!(LATENCY, 1_000_000_000);
+heatmap!(CARDINALITY, 1_000, "some description");
+
+#[test]
+fn metric_name_as_expected() {
+    let metrics = metrics().static_metrics();
+    assert_eq!(metrics.len(), 2);
+    assert_eq!(metrics[1].name(), "latency");
+    assert_eq!(metrics[1].description(), None);
+}
+
+#[test]
+fn metric_name_and_description_as_expected() {
+    let metrics = metrics().static_metrics();
+    assert_eq!(metrics.len(), 2);
+    assert_eq!(metrics[0].name(), "cardinality");
+    assert_eq!(
+        metrics[0].description(),
+        Some("some description")
+    );
+}

--- a/metrics/tests/heatmap.rs
+++ b/metrics/tests/heatmap.rs
@@ -20,8 +20,5 @@ fn metric_name_and_description_as_expected() {
     let metrics = metrics().static_metrics();
     assert_eq!(metrics.len(), 2);
     assert_eq!(metrics[0].name(), "cardinality");
-    assert_eq!(
-        metrics[0].description(),
-        Some("some description")
-    );
+    assert_eq!(metrics[0].description(), Some("some description"));
 }


### PR DESCRIPTION
Heatmap macro was broken by #122

Fixes the heatmap initialization and adds a test to prevent a miss here in the future.
