### PR TITLE
fix(metrics): Remove public re-exports of rustcommon-time from metrics

### DIFF
--- a/metrics/derive/src/lib.rs
+++ b/metrics/derive/src/lib.rs
@@ -23,8 +23,8 @@ mod metric;
 ///   allows the `metric` macro to be used within other macros that get exported
 ///   to third-party crates which may not have added `rustcommon_metrics` to
 ///   their Cargo.toml.
-/// - (optional) `description`: A textual description of the metric.
-///   If not specified, or specified as a blank string then defaults to None
+/// - (optional) `description`: A textual description of the metric. If not
+///   specified, or specified as a blank string then defaults to None
 ///
 /// [`Deref`]: std::ops::Deref
 /// [`DerefMut`]: std::ops::DerefMut

--- a/metrics/src/lazy.rs
+++ b/metrics/src/lazy.rs
@@ -26,12 +26,14 @@ use std::ops::{Deref, DerefMut};
 /// # fn main() {
 /// # use rustcommon_metrics::*;
 /// #[metric]
-/// static HEATMAP: Lazy<Heatmap> = Lazy::new(|| Heatmap::new(
-///     100,
-///     2,
-///     Duration::<Nanoseconds<u64>>::from_secs(30),
-///     Duration::<Nanoseconds<u64>>::from_secs(1),
-/// ));
+/// static HEATMAP: Lazy<Heatmap> = Lazy::new(|| {
+///     Heatmap::new(
+///         100,
+///         2,
+///         Duration::<Nanoseconds<u64>>::from_secs(30),
+///         Duration::<Nanoseconds<u64>>::from_secs(1),
+///     )
+/// });
 /// # }
 /// # #[cfg(not(feature = "heatmap"))] fn main() {}
 /// ```

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -104,14 +104,16 @@ pub mod export {
 macro_rules! counter {
     ($name:ident) => {
         #[metric(
-            name = $crate::to_lowercase!($name)
+            name = $crate::to_lowercase!($name),
+            crate = $crate
         )]
         pub static $name: $crate::Counter = $crate::Counter::new();
     };
     ($name:ident, $description:tt) => {
         #[metric(
             name = $crate::to_lowercase!($name),
-            description = $description
+            description = $description,
+            crate = $crate
         )]
         pub static $name: $crate::Counter = $crate::Counter::new();
     };
@@ -122,14 +124,16 @@ macro_rules! counter {
 macro_rules! gauge {
     ($name:ident) => {
         #[metric(
-            name = $crate::to_lowercase!($name)
+            name = $crate::to_lowercase!($name),
+            crate = $crate
         )]
         pub static $name: $crate::Gauge = $crate::Gauge::new();
     };
     ($name:ident, $description:tt) => {
         #[metric(
             name = $crate::to_lowercase!($name),
-            description = $description
+            description = $description,
+            crate = $crate
         )]
         pub static $name: $crate::Gauge = $crate::Gauge::new();
     };
@@ -140,7 +144,8 @@ macro_rules! gauge {
 macro_rules! heatmap {
     ($name:ident, $max:expr) => {
         #[metric(
-            name = $crate::to_lowercase!($name)
+            name = $crate::to_lowercase!($name),
+            crate = $crate
         )]
         pub static $name: $crate::Relaxed<$crate::Heatmap> = $crate::Relaxed::new(|| {
             $crate::Heatmap::builder()
@@ -156,7 +161,8 @@ macro_rules! heatmap {
     ($name:ident, $max:expr, $description:tt) => {
         #[metric(
             name = $crate::to_lowercase!($name),
-            description = $description
+            description = $description,
+            crate = $crate
         )]
         pub static $name: $crate::Relaxed<$crate::Heatmap> = $crate::Relaxed::new(|| {
             $crate::Heatmap::builder()

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -87,6 +87,8 @@ pub use crate::lazy::{Lazy, Relaxed};
 
 pub use rustcommon_metrics_derive::metric;
 
+pub extern crate rustcommon_time as time;
+
 #[doc(hidden)]
 pub use rustcommon_metrics_derive::to_lowercase;
 

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -85,12 +85,15 @@ pub use crate::gauge::Gauge;
 pub use crate::heatmap::Heatmap;
 pub use crate::lazy::{Lazy, Relaxed};
 
-pub use rustcommon_metrics_derive::{metric, to_lowercase};
-pub use rustcommon_time::*;
+pub use rustcommon_metrics_derive::metric;
+
+#[doc(hidden)]
+pub use rustcommon_metrics_derive::to_lowercase;
 
 #[doc(hidden)]
 pub mod export {
     pub extern crate linkme;
+    pub use rustcommon_time::{Duration, Nanoseconds};
 
     #[linkme::distributed_slice]
     pub static METRICS: [crate::MetricEntry] = [..];
@@ -101,16 +104,16 @@ pub mod export {
 macro_rules! counter {
     ($name:ident) => {
         #[metric(
-            name = rustcommon_metrics::to_lowercase!($name)
+            name = $crate::to_lowercase!($name)
         )]
-        pub static $name: Counter = Counter::new();
+        pub static $name: $crate::Counter = $crate::Counter::new();
     };
     ($name:ident, $description:tt) => {
         #[metric(
-            name = rustcommon_metrics::to_lowercase!($name),
+            name = $crate::to_lowercase!($name),
             description = $description
         )]
-        pub static $name: Counter = Counter::new();
+        pub static $name: $crate::Counter = $crate::Counter::new();
     };
 }
 
@@ -119,16 +122,16 @@ macro_rules! counter {
 macro_rules! gauge {
     ($name:ident) => {
         #[metric(
-            name = rustcommon_metrics::to_lowercase!($name)
+            name = $crate::to_lowercase!($name)
         )]
-        pub static $name: Gauge = Gauge::new();
+        pub static $name: $crate::Gauge = $crate::Gauge::new();
     };
     ($name:ident, $description:tt) => {
         #[metric(
-            name = rustcommon_metrics::to_lowercase!($name),
+            name = $crate::to_lowercase!($name),
             description = $description
         )]
-        pub static $name: Gauge = Gauge::new();
+        pub static $name: $crate::Gauge = $crate::Gauge::new();
     };
 }
 
@@ -137,31 +140,31 @@ macro_rules! gauge {
 macro_rules! heatmap {
     ($name:ident, $max:expr) => {
         #[metric(
-            name = rustcommon_metrics::to_lowercase!($name)
+            name = $crate::to_lowercase!($name)
         )]
-        pub static $name: Relaxed<Heatmap> = Relaxed::new(|| {
-            Heatmap::builder()
+        pub static $name: $crate::Relaxed<$crate::Heatmap> = $crate::Relaxed::new(|| {
+            $crate::Heatmap::builder()
                 .maximum_value($max as _)
                 .min_resolution(1)
                 .min_resolution_range(1024)
-                .span(rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(60))
-                .resolution(rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(1))
+                .span($crate::export::Duration::<$crate::export::Nanoseconds<u64>>::from_secs(60))
+                .resolution($crate::export::Duration::<$crate::export::Nanoseconds<u64>>::from_secs(1))
                 .build()
                 .expect("bad heatmap configuration")
         });
     };
     ($name:ident, $max:expr, $description:tt) => {
         #[metric(
-            name = rustcommon_metrics::to_lowercase!($name),
+            name = $crate::to_lowercase!($name),
             description = $description
         )]
-        pub static $name: Relaxed<Heatmap> = Relaxed::new(|| {
-            Heatmap::builder()
+        pub static $name: $crate::Relaxed<$crate::Heatmap> = $crate::Relaxed::new(|| {
+            $crate::Heatmap::builder()
                 .maximum_value($max as _)
                 .min_resolution(1)
                 .min_resolution_range(1024)
-                .span(rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(60))
-                .resolution(rustcommon_metrics::Duration::<rustcommon_metrics::Nanoseconds<u64>>::from_secs(1))
+                .span($crate::export::Duration::<$crate::export::Nanoseconds<u64>>::from_secs(60))
+                .resolution($crate::export::Duration::<$crate::export::Nanoseconds<u64>>::from_secs(1))
                 .build()
                 .expect("bad heatmap configuration")
         });

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -103,14 +103,14 @@ pub mod export {
 #[rustfmt::skip]
 macro_rules! counter {
     ($name:ident) => {
-        #[metric(
+        #[$crate::metric(
             name = $crate::to_lowercase!($name),
             crate = $crate
         )]
         pub static $name: $crate::Counter = $crate::Counter::new();
     };
     ($name:ident, $description:tt) => {
-        #[metric(
+        #[$crate::metric(
             name = $crate::to_lowercase!($name),
             description = $description,
             crate = $crate
@@ -123,14 +123,14 @@ macro_rules! counter {
 #[rustfmt::skip]
 macro_rules! gauge {
     ($name:ident) => {
-        #[metric(
+        #[$crate::metric(
             name = $crate::to_lowercase!($name),
             crate = $crate
         )]
         pub static $name: $crate::Gauge = $crate::Gauge::new();
     };
     ($name:ident, $description:tt) => {
-        #[metric(
+        #[$crate::metric(
             name = $crate::to_lowercase!($name),
             description = $description,
             crate = $crate
@@ -143,7 +143,7 @@ macro_rules! gauge {
 #[rustfmt::skip]
 macro_rules! heatmap {
     ($name:ident, $max:expr) => {
-        #[metric(
+        #[$crate::metric(
             name = $crate::to_lowercase!($name),
             crate = $crate
         )]
@@ -159,7 +159,7 @@ macro_rules! heatmap {
         });
     };
     ($name:ident, $max:expr, $description:tt) => {
-        #[metric(
+        #[$crate::metric(
             name = $crate::to_lowercase!($name),
             description = $description,
             crate = $crate

--- a/metrics/tests/heatmap.rs
+++ b/metrics/tests/heatmap.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use rustcommon_metrics::{heatmap, metrics};
 
 heatmap!(LATENCY, 1_000_000_000);
 heatmap!(CARDINALITY, 1_000, "some description");

--- a/metrics/tests/metric_macros.rs
+++ b/metrics/tests/metric_macros.rs
@@ -1,0 +1,16 @@
+use rustcommon_metrics::{counter, gauge, heatmap};
+
+counter!(A_COUNTER);
+gauge!(A_GAUGE);
+heatmap!(A_HEATMAP, 50);
+
+#[test]
+fn metrics_are_present() {
+    let metrics = rustcommon_metrics::metrics();
+    let metrics = metrics.static_metrics();
+
+    assert_eq!(metrics.len(), 3);
+    assert!(metrics.iter().any(|metric| metric.name() == "a_counter"));
+    assert!(metrics.iter().any(|metric| metric.name() == "a_gauge"));
+    assert!(metrics.iter().any(|metric| metric.name() == "a_heatmap"));
+}


### PR DESCRIPTION
## Problem
This PR fixes two main problems:
- the metrics crate re-exports the entirety of the `rustcommon_time` crate
- all the new macros in the metrics crate have `rustcommon_metrics` hardcoded as the crate name which will break if the crate is ever renamed or used in a edition 2015/2018 crate with a module called `rustcommon_metrics`

## Solution
Here's what I've changed:
- the relevant re-exports from time have been added to the hidden `exports` module (that's what it is there for)
- I have also marked the `to_lowercase!` macro as `#[doc(hidden)]` since it's not relevant to the public api of the crate
- I have gone through and replaced any instance of `rustcommon_metrics` in the exported macros with `$crate` so that it will refer to the right crate
- I have also added `crate = $crate` to the invocations of the `metric` macro so that it will continue to work even if `rustcommon_metrics` is not available when `counter!`, `heatmap!`, or `gauge!` are used.

I've also gone and added a test case that stresses at least some of these edge cases.
